### PR TITLE
Allow `clippy::match_wild_err_arm`

### DIFF
--- a/proconio/src/read.rs
+++ b/proconio/src/read.rs
@@ -17,9 +17,12 @@ use std::str::FromStr;
 impl<T: FromStr> Readable for T {
     type Output = T;
     fn read<R: BufRead, S: Source<R>>(source: &mut S) -> T {
+        // Using `match` instead of `expect()` is to prevent requiring `T::Err`
+        // to be a `Debug`.
+        #[allow(clippy::match_wild_err_arm)]
         match source.next_token_unwrap().parse() {
             Ok(v) => v,
-            Err(_e) => panic!("failed to parse input."),
+            Err(_) => panic!("failed to parse input."),
         }
     }
 }


### PR DESCRIPTION
すべてのエラーをマッチ `Err(_) = ...` して何もせず panic!() すると `clippy::match_wild_err_arm` が発行されてよりよいハンドリングをするよう提案されるようですが、この場面ではどうしようもないので無視することにします。