### PR TITLE
Rewrite `#[fastout]`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         channel:
-          - 1.40.0
+          - 1.42.0
           - stable
           - beta
         target_triple:
@@ -41,23 +41,23 @@ jobs:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
         include:
-          - channel: 1.40.0
+          - channel: 1.42.0
             target_triple: x86_64-pc-windows-msvc
             host_triple: x86_64-pc-windows-msvc
             os: windows-latest
-          - channel: 1.40.0
+          - channel: 1.42.0
             target_triple: x86_64-pc-windows-gnu
             host_triple: x86_64-pc-windows-gnu
             os: windows-latest
-          - channel: 1.40.0
+          - channel: 1.42.0
             target_triple: x86_64-apple-darwin
             host_triple: x86_64-apple-darwin
             os: macOS-latest
-          - channel: 1.40.0
+          - channel: 1.42.0
             target_triple: x86_64-unknown-linux-gnu
             host_triple: x86_64-unknown-linux-gnu
             os: ubuntu-18.04
-          - channel: 1.40.0
+          - channel: 1.42.0
             target_triple: x86_64-unknown-linux-musl
             host_triple: x86_64-unknown-linux-gnu
             os: ubuntu-18.04

--- a/proconio-derive/Cargo.toml
+++ b/proconio-derive/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro2 = "1.0.9"
 
 [dependencies.syn]
 version = "1.0.17"
-features = ["full", "extra-traits"]
+features = ["full", "extra-traits", "visit"]
 
 [dev-dependencies.proconio]
 version = "0.3.0"

--- a/proconio-derive/Cargo.toml
+++ b/proconio-derive/Cargo.toml
@@ -12,11 +12,11 @@ description = "Procedural macros for proconio"
 proc-macro = true
 
 [dependencies]
-quote = "0.6.12"
-proc-macro2 = "0.4.30"
+quote = "1.0.3"
+proc-macro2 = "1.0.9"
 
 [dependencies.syn]
-version = "0.15.34"
+version = "1.0.17"
 features = ["full", "extra-traits"]
 
 [dev-dependencies.proconio]

--- a/proconio-derive/src/fastout.rs
+++ b/proconio-derive/src/fastout.rs
@@ -6,14 +6,13 @@
 // distributed except according to those terms.
 
 use proc_macro::TokenStream;
-use proc_macro2::{Span as Span2, TokenStream as TokenStream2};
+use proc_macro2::Span as Span2;
 use quote::quote;
 use quote::ToTokens;
-use std::borrow::BorrowMut;
-use std::mem::replace;
 use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
 use syn::{parse_macro_input, parse_quote};
-use syn::{Block, Expr, ExprMacro, ItemFn, Path, Stmt};
+use syn::{Block, ExprClosure, ExprMacro, ItemFn, Macro, Path, Stmt};
 
 pub fn main(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut itemfn: ItemFn = parse_macro_input!(input as ItemFn);
@@ -31,107 +30,47 @@ pub fn main(attr: TokenStream, input: TokenStream) -> TokenStream {
         return itemfn.into_token_stream().into();
     }
 
-    // replace print
-    replace_print_macro_in_block(&mut itemfn.block);
+    if let Err(compile_errors) = error_for_print_macros_in_closures(&itemfn.block) {
+        itemfn.block.stmts = compile_errors;
+        return itemfn.into_token_stream().into();
+    }
 
-    // adds codes for preparing / flushing BufWriter to the function body.
-    insert_bufwriter_to_block(&mut itemfn.block);
+    itemfn.block = Box::new(insert_new_print_macros(&itemfn.block));
 
     itemfn.into_token_stream().into()
 }
 
-fn replace_print_macro_in_block(block: &mut Block) -> Vec<Span2> {
-    let mut did_replace = Vec::new();
-
-    for stmt in &mut block.stmts {
-        did_replace.extend(replace_print_macro_in_stmt(stmt));
-    }
-
-    did_replace
-}
-
-fn replace_print_macro_in_stmt(stmt: &mut Stmt) -> Vec<Span2> {
-    let expr = match stmt {
-        Stmt::Local(local) => match &mut local.init {
-            Some((_eq, init)) => init.borrow_mut(),
-            _ => return Vec::new(),
-        },
-        Stmt::Expr(expr) => expr,
-        Stmt::Semi(expr, _) => expr,
-        _ => return Vec::new(),
+fn error_for_print_macros_in_closures(block: &Block) -> std::result::Result<(), Vec<Stmt>> {
+    let mut visitor = BlockVisitor::default();
+    visitor.visit_block(block);
+    return if visitor.compile_errors.is_empty() {
+        Ok(())
+    } else {
+        Err(visitor.compile_errors)
     };
 
-    replace_print_macro_in_expr(expr)
-}
-
-fn replace_print_macro_in_expr(expr: &mut Expr) -> Vec<Span2> {
-    macro_rules! rbox {
-        ($e:expr) => {
-            replace_print_macro_in_expr($e.borrow_mut())
-        };
+    #[derive(Default)]
+    struct BlockVisitor {
+        compile_errors: Vec<Stmt>,
     }
 
-    macro_rules! riter {
-        ($i:expr) => {
-            $i.iter_mut().fold(Vec::new(), |mut did_replace, e| {
-                did_replace.extend(replace_print_macro_in_expr(e));
-                did_replace
-            })
-        };
+    impl<'ast> Visit<'ast> for BlockVisitor {
+        fn visit_expr_closure(&mut self, item: &'ast ExprClosure) {
+            let mut visitor = ClosureVisitor::default();
+            visitor.visit_expr_closure(item);
+            self.compile_errors.extend(visitor.compile_errors);
+        }
     }
 
-    let emac = match expr {
-        Expr::Macro(emac) => emac,
-        Expr::Box(i) => return rbox!(i.expr),
-        Expr::InPlace(i) => {
-            let mut did_replace = Vec::new();
-            did_replace.extend(rbox!(i.place));
-            did_replace.extend(rbox!(i.value));
-            return did_replace;
-        }
-        Expr::Array(i) => return riter!(i.elems),
-        Expr::Call(i) => return riter!(i.args),
-        Expr::MethodCall(i) => {
-            let mut did_replace = Vec::new();
-            did_replace.extend(rbox!(i.receiver));
-            did_replace.extend(riter!(i.args));
-            return did_replace;
-        }
-        Expr::Tuple(i) => return riter!(i.elems),
-        Expr::Binary(i) => {
-            let mut did_replace = Vec::new();
-            did_replace.extend(rbox!(i.left));
-            did_replace.extend(rbox!(i.right));
-            return did_replace;
-        }
-        Expr::Unary(i) => return rbox!(i.expr),
-        Expr::Cast(i) => return rbox!(i.expr),
-        Expr::Type(i) => return rbox!(i.expr),
-        Expr::Let(i) => return rbox!(i.expr),
-        Expr::If(i) => {
-            let mut did_replace = rbox!(i.cond);
-            did_replace.extend(replace_print_macro_in_block(&mut i.then_branch));
-            if let Some((_, e)) = &mut i.else_branch {
-                did_replace.extend(rbox!(e));
-            }
-            return did_replace;
-        }
-        Expr::While(i) => {
-            let mut did_replace = rbox!(i.cond);
-            did_replace.extend(replace_print_macro_in_block(&mut i.body));
-            return did_replace;
-        }
-        Expr::ForLoop(i) => {
-            let mut did_replace = rbox!(i.expr);
-            did_replace.extend(replace_print_macro_in_block(&mut i.body));
-            return did_replace;
-        }
-        Expr::Loop(i) => return replace_print_macro_in_block(&mut i.body),
-        Expr::Match(i) => return rbox!(i.expr),
-        Expr::Closure(i) => {
-            let did_replace = rbox!(i.body);
+    #[derive(Default)]
+    struct ClosureVisitor {
+        compile_errors: Vec<Stmt>,
+    }
 
-            if !did_replace.is_empty() {
+    impl<'ast> Visit<'ast> for ClosureVisitor {
+        fn visit_expr_macro(&mut self, item: &'ast ExprMacro) {
+            let Macro { path, .. } = &item.mac;
+            if equals(path, "print") || equals(path, "println") {
                 // Closure containing print macro is prohibited because closure *may* passed to the
                 // function which requires the closure to be `Send`.  For example, std::thread::spawn()
                 // takes an closure and run the closure in another thread.  That causes an error since
@@ -144,205 +83,75 @@ fn replace_print_macro_in_expr(expr: &mut Expr) -> Vec<Span2> {
                 // requires `Send` or not for now.
 
                 // emit an error for each position of print macro.
-                let mut stmts: Vec<Stmt> = Vec::new();
-                for span in did_replace {
-                    let compile_error = crate::compile_error_at(
-                        quote!(
-                            "Closures in a #[fastout] function cannot contain `print!` or \
-                            `println!` macro\n\
-                            \n\
-                            note: If you want to run your entire logic in a thread having extended \
-                            size of stack, you can define a new function instead.  See \
-                            documentation (https://docs.rs/proconio/#\
-                            closures-having-print-or-println-in-fastout-function) for more \
-                            details.\n\
-                            \n\
-                            note: This is because if you use this closure with \
-                            `std::thread::spawn()` or any other functions requiring `Send` for an \
-                            argument closure, the compiler emits an error about thread unsafety for \
-                            our internal implementations.  If you are using the closure just in a \
-                            single thread, it's actually no problem, but we cannot check the trait \
-                            bounds at the macro-expansion time.  So for now, all closures having \
-                            `print!` or `println!` is prohibited regardless of the `Send` \
-                            requirements."
-                        ),
-                        span,
-                        span,
-                    );
-
-                    stmts.push(compile_error)
-                }
-
-                *expr = parse_quote!({ #(#stmts)* });
+                self.compile_errors.push(crate::compile_error_at(
+                    quote!(
+                        "Closures in a #[fastout] function cannot contain `print!` or \
+                        `println!` macro\n\
+                        \n\
+                        note: If you want to run your entire logic in a thread having extended \
+                        size of stack, you can define a new function instead.  See \
+                        documentation (https://docs.rs/proconio/#\
+                        closures-having-print-or-println-in-fastout-function) for more \
+                        details.\n\
+                        \n\
+                        note: This is because if you use this closure with \
+                        `std::thread::spawn()` or any other functions requiring `Send` for an \
+                        argument closure, the compiler emits an error about thread unsafety for \
+                        our internal implementations.  If you are using the closure just in a \
+                        single thread, it's actually no problem, but we cannot check the trait \
+                        bounds at the macro-expansion time.  So for now, all closures having \
+                        `print!` or `println!` is prohibited regardless of the `Send` \
+                        requirements."
+                    ),
+                    item.span(),
+                    item.span(),
+                ));
             }
-
-            // To avoid multiple compilation error for the same println, return empty vec.
-            return Vec::new();
+            visit::visit_expr_macro(self, item);
         }
-        Expr::Unsafe(i) => return replace_print_macro_in_block(&mut i.block),
-        Expr::Block(i) => return replace_print_macro_in_block(&mut i.block),
-        Expr::Assign(i) => {
-            let mut did_replace = Vec::new();
-            did_replace.extend(rbox!(i.left));
-            did_replace.extend(rbox!(i.right));
-            return did_replace;
-        }
-        Expr::AssignOp(i) => {
-            let mut did_replace = Vec::new();
-            did_replace.extend(rbox!(i.left));
-            did_replace.extend(rbox!(i.right));
-            return did_replace;
-        }
-        Expr::Field(i) => return rbox!(i.base),
-        Expr::Index(i) => {
-            let mut did_replace = Vec::new();
-            did_replace.extend(rbox!(i.expr));
-            did_replace.extend(rbox!(i.index));
-            return did_replace;
-        }
-        Expr::Range(i) => {
-            let mut did_replace = Vec::new();
-            if let Some(from) = &mut i.from {
-                did_replace.extend(rbox!(from));
-            }
-            if let Some(to) = &mut i.to {
-                did_replace.extend(rbox!(to));
-            }
-            return did_replace;
-        }
-        Expr::Reference(i) => return rbox!(i.expr),
-        Expr::Break(i) => {
-            return match &mut i.expr {
-                Some(e) => rbox!(e),
-                None => Vec::new(),
-            };
-        }
-        Expr::Return(i) => {
-            return match &mut i.expr {
-                Some(e) => rbox!(e),
-                None => Vec::new(),
-            };
-        }
-        Expr::Struct(i) => {
-            let mut did_replace = i.fields.iter_mut().fold(Vec::new(), |mut did_replace, f| {
-                did_replace.extend(replace_print_macro_in_expr(&mut f.expr));
-                did_replace
-            });
-            if let Some(rest) = &mut i.rest {
-                did_replace.extend(rbox!(rest));
-            }
-            return did_replace;
-        }
-        Expr::Repeat(i) => {
-            let mut did_replace = Vec::new();
-            did_replace.extend(rbox!(i.expr));
-            did_replace.extend(rbox!(i.len));
-            return did_replace;
-        }
-        Expr::Paren(i) => return rbox!(i.expr),
-        Expr::Group(i) => return rbox!(i.expr),
-        Expr::Try(i) => return rbox!(i.expr),
-        Expr::Async(i) => return replace_print_macro_in_block(&mut i.block),
-        Expr::TryBlock(i) => return replace_print_macro_in_block(&mut i.block),
-        Expr::Yield(i) => {
-            return match &mut i.expr {
-                Some(e) => rbox!(e),
-                None => Vec::new(),
-            }
-        }
-        Expr::Lit(_) => return Vec::new(),
-        Expr::Path(_) => return Vec::new(),
-        Expr::Continue(_) => return Vec::new(),
-        Expr::Verbatim(_) => return Vec::new(),
-    };
-
-    let emac = replace(
-        emac,
-        parse_quote!(compile_error!(concat!(
-            "Replacing print macro did not complete.  ",
-            "This is a bug in `proconio`.  ",
-            "Please report this issue from ",
-            "<https://github.com/statiolake/proconio-rs/issues>."
-        ))),
-    );
-
-    let (did_replace, replaced) = generate_print_replaced_expr(emac);
-    *expr = replaced;
-    did_replace
-}
-
-fn generate_print_replaced_expr(emac: ExprMacro) -> (Vec<Span2>, Expr) {
-    // helper macro to parse path
-    macro_rules! path {
-        ($($tt:tt)*) => {
-            syn::parse::<Path>(quote!($($tt)*).into())
-                .expect(concat!(
-                    "Failed to parse path.  ",
-                    "This is a bug in `proconio`.  ",
-                    "Please report this issue from ",
-                    "<https://github.com/statiolake/proconio-rs/issues>."
-                ))
-        };
     }
 
-    // replace print! -> write!
-    let path_print = vec![path!(::std::print), path!(std::print), path!(print)];
-    let path_println = vec![path!(::std::println), path!(std::println), path!(println)];
-
-    let has_newline = if path_print.contains(&emac.mac.path) {
-        false
-    } else if path_println.contains(&emac.mac.path) {
-        true
-    } else {
-        // If the macro is not `print*!`, do nothing.
-        return (Vec::new(), Expr::Macro(emac));
-    };
-
-    // preserve span for returning
-    let span = emac.mac.span();
-    // if macro is with new line version, support that.
-    let format_args_args = if has_newline {
-        // take ownership of TokenStream from the macro temporary.
-        let mut tts = emac.mac.tts.into_iter();
-
-        // `lit` must be the format string literal.
-        //  I don't care if `lit` is actually a string literal here since that will be error later
-        //  in `format_args!`.
-        let lit = tts.next();
-
-        // `rest` are format arguments.
-        let rest: TokenStream2 = tts.collect();
-
-        // generate the newlined version of format string and interpolate it.
-        match lit {
-            Some(first) => quote!(concat!(#first, "\n") #rest),
-            None => quote!("\n"),
-        }
-    } else {
-        // otherwise, no translations are needed.
-        emac.mac.tts
-    };
-
-    // replace the expression of `print!` and `println!` macro call.
-    let replaced = parse_quote! {
-        <::std::io::BufWriter<::std::io::StdoutLock> as ::std::io::Write>::write_fmt(
-            &mut __proconio_stdout,
-            format_args!(#format_args_args)
-        )
-        .unwrap()
-    };
-
-    (vec![span], replaced)
+    fn equals(path: &Path, ident: &str) -> bool {
+        matches!(path.get_ident(), Some(path_ident) if path_ident == ident)
+    }
 }
 
-fn insert_bufwriter_to_block(block: &mut Block) {
-    let replaced: Block = parse_quote! {{
+fn insert_new_print_macros(block: &Block) -> Block {
+    parse_quote! {{
         let __proconio_stdout = ::std::io::stdout();
         let mut __proconio_stdout = ::std::io::BufWriter::new(__proconio_stdout.lock());
+
+        #[allow(unused_macros)]
+        macro_rules! print {
+            ($($tt:tt)*) => {
+                <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
+                    &mut __proconio_stdout,
+                    format_args!($($tt)*),
+                )
+                .unwrap()
+            };
+        }
+
+        #[allow(unused_macros)]
+        macro_rules! println {
+            () => {
+                <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_all(
+                    &mut __proconio_stdout,
+                    b"\n",
+                )
+                .unwrap()
+            };
+            ($fmt:literal $($tt:tt)*) => {
+                <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
+                    &mut __proconio_stdout,
+                    format_args!(::std::concat!($fmt, "\n") $($tt)*),
+                )
+                .unwrap()
+            };
+        }
+
         let __proconio_res = #block;
         <::std::io::BufWriter<::std::io::StdoutLock> as ::std::io::Write>::flush(&mut __proconio_stdout).unwrap();
         return __proconio_res;
-    }};
-
-    replace(block, replaced);
+    }}
 }

--- a/proconio-derive/src/lib.rs
+++ b/proconio-derive/src/lib.rs
@@ -128,14 +128,38 @@ pub fn derive_readable(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 /// let __proconio_stdout = ::std::io::stdout();
 /// let mut __proconio_stdout = ::std::io::BufWriter::new(__proconio_stdout.lock());
+///
+/// #[allow(unused_macros)]
+/// macro_rules! print {
+///     ($($tt:tt)*) => {
+///         <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
+///             &mut __proconio_stdout,
+///             format_args!($($tt)*),
+///         )
+///         .unwrap()
+///     };
+/// }
+///
+/// #[allow(unused_macros)]
+/// macro_rules! println {
+///     () => {
+///         <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_all(
+///             &mut __proconio_stdout,
+///             b"\n",
+///         )
+///         .unwrap()
+///     };
+///     ($fmt:literal $($tt:tt)*) => {
+///         <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
+///             &mut __proconio_stdout,
+///             format_args!(::std::concat!($fmt, "\n") $($tt)*),
+///         )
+///         .unwrap()
+///     };
+/// }
+///
 /// let __proconio_res = {
-///     // Your code goes here, with `print!` replaced by
-///     //
-///     // <::std::io::BufWriter<::std::io::StdoutLock> as ::std::io::Write>::write_fmt(
-///     //     &mut __proconio_stdout,
-///     //     format_args!(/* print! macro arguments */)
-///     // ).unwrap()
-///     //
+///     // Your code goes here
 /// };
 /// <::std::io::BufWriter<::std::io::StdoutLock> as ::std::io::Write>::flush(
 ///     &mut __proconio_stdout

--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -23,7 +23,7 @@ path = "tests/fastout.rs"
 required-features = ["derive"]
 
 [dependencies]
-lazy_static = "1.3.0"
+lazy_static = "1.4.0"
 
 [dependencies.proconio-derive]
 version = "0.1.0"

--- a/proconio/tests/fastout.rs
+++ b/proconio/tests/fastout.rs
@@ -22,8 +22,9 @@ fn main() {
     // std::thread::spawn(|| {
     //     std::println!("hello");
     // }); // of course error
+    println!();
     println!("hello, world, {}!", name);
-    std::println!("{}", foo());
+    println!("{}", foo());
     print!("{}{}, ", 'h', "ello"); // "hello"       (no newline)
     println!("{}!", "world"); // "world!\n"
     println!("{}", 123_456_789); // "123456789\n"


### PR DESCRIPTION
Fixes #8.

1. Migrate to `syn` v1.
2. Bump the MSRV to 1.42.0.
3. The new `fastout` will be like this:

    ```rust
    let __proconio_stdout = ::std::io::stdout();
    let mut __proconio_stdout = ::std::io::BufWriter::new(__proconio_stdout.lock());

    // proc-macros can produce `macro_rules!` since Rust 1.40.0

    #[allow(unused_macros)]
    macro_rules! print {
        ($($tt:tt)*) => {
            <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
                &mut __proconio_stdout,
                format_args!($($tt)*),
            )
            .unwrap()
        };
    }

    #[allow(unused_macros)]
    macro_rules! println {
        () => {
            <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_all(
                &mut __proconio_stdout,
                b"\n",
            )
            .unwrap()
        };
        ($fmt:literal $($tt:tt)*) => {
            <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
                &mut __proconio_stdout,
                format_args!(::std::concat!($fmt, "\n") $($tt)*),
            )
            .unwrap()
        };
    }

    let __proconio_res = {
        // AS IS
        println!("Hello!");

        // `print!`/`println!` in closures still produce explicit errors
        //thread::Builder::new()
        //    .stack_size(1024usize.pow(3))
        //    .spawn(|| println!("Hi"))
        //    .unwrap();
    };
    <::std::io::BufWriter<::std::io::StdoutLock> as ::std::io::Write>::flush(
        &mut __proconio_stdout
    ).unwrap();
    return __proconio_res;
    ```

    The new implementation does not replace qualified macros i.e. `std::print!`. `std::println!`, `::std::print!` and `::std::println!`. So this change may be breaking.
