### PR TITLE
Use `std::write!` and `std::writeln!` to improve error messages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,8 @@ jobs:
           command: clippy
           args: --workspace --all-targets --all-features --target ${{ matrix.target_triple }} -v -- -D warnings
 
-      - name: '`cargo test --no-fail-fast --workspace --target ${{ matrix.target_triple }} -v`'
+      - name: '`cargo test --no-fail-fast --workspace --all-features --target ${{ matrix.target_triple }} -v`'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-fail-fast --workspace --target ${{ matrix.target_triple }} -v
+          args: --no-fail-fast --workspace --all-features --target ${{ matrix.target_triple }} -v

--- a/proconio-derive/src/fastout.rs
+++ b/proconio-derive/src/fastout.rs
@@ -123,31 +123,18 @@ fn insert_new_print_macros(block: &Block) -> Block {
 
         #[allow(unused_macros)]
         macro_rules! print {
-            ($($tt:tt)*) => {
-                <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
-                    &mut __proconio_stdout,
-                    format_args!($($tt)*),
-                )
-                .unwrap()
-            };
+            ($($tt:tt)*) => {{
+                use std::io::Write as _;
+                ::std::write!(__proconio_stdout, $($tt)*).unwrap();
+            }};
         }
 
         #[allow(unused_macros)]
         macro_rules! println {
-            () => {
-                <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_all(
-                    &mut __proconio_stdout,
-                    b"\n",
-                )
-                .unwrap()
-            };
-            ($fmt:literal $($tt:tt)*) => {
-                <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
-                    &mut __proconio_stdout,
-                    format_args!(::std::concat!($fmt, "\n") $($tt)*),
-                )
-                .unwrap()
-            };
+            ($($tt:tt)*) => {{
+                use std::io::Write as _;
+                ::std::writeln!(__proconio_stdout, $($tt)*).unwrap();
+            }};
         }
 
         let __proconio_res = #block;

--- a/proconio-derive/src/lib.rs
+++ b/proconio-derive/src/lib.rs
@@ -131,31 +131,18 @@ pub fn derive_readable(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// #[allow(unused_macros)]
 /// macro_rules! print {
-///     ($($tt:tt)*) => {
-///         <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
-///             &mut __proconio_stdout,
-///             format_args!($($tt)*),
-///         )
-///         .unwrap()
-///     };
+///     ($($tt:tt)*) => {{
+///         use std::io::Write as _;
+///         ::std::write!(__proconio_stdout, $($tt)*).unwrap();
+///     }};
 /// }
 ///
 /// #[allow(unused_macros)]
 /// macro_rules! println {
-///     () => {
-///         <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_all(
-///             &mut __proconio_stdout,
-///             b"\n",
-///         )
-///         .unwrap()
-///     };
-///     ($fmt:literal $($tt:tt)*) => {
-///         <::std::io::BufWriter<::std::io::StdoutLock<'_>> as ::std::io::Write>::write_fmt(
-///             &mut __proconio_stdout,
-///             format_args!(::std::concat!($fmt, "\n") $($tt)*),
-///         )
-///         .unwrap()
-///     };
+///     ($($tt:tt)*) => {{
+///         use std::io::Write as _;
+///         ::std::writeln!(__proconio_stdout, $($tt)*).unwrap();
+///     }};
 /// }
 ///
 /// let __proconio_res = {

--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -22,6 +22,11 @@ name = "fastout"
 path = "tests/fastout.rs"
 required-features = ["derive"]
 
+[[test]]
+name = "ui"
+path = "tests/ui.rs"
+required-features = ["derive"]
+
 [dependencies]
 lazy_static = "1.4.0"
 
@@ -29,6 +34,10 @@ lazy_static = "1.4.0"
 version = "0.2.0"
 path = "../proconio-derive"
 optional = true
+
+[dev-dependencies]
+rustversion = "1.0.2"
+trybuild = "1.0.24"
 
 [features]
 derive = ["proconio-derive"]

--- a/proconio/tests/ui.rs
+++ b/proconio/tests/ui.rs
@@ -1,0 +1,5 @@
+#[rustversion::stable(1.42.0)]
+#[test]
+fn ui() {
+    trybuild::TestCases::new().compile_fail("./tests/ui/**/*.rs");
+}

--- a/proconio/tests/ui/fastout/argument-never-used.rs
+++ b/proconio/tests/ui/fastout/argument-never-used.rs
@@ -1,0 +1,6 @@
+use proconio::fastout;
+
+#[fastout]
+fn main() {
+    println!("", 42);
+}

--- a/proconio/tests/ui/fastout/argument-never-used.stderr
+++ b/proconio/tests/ui/fastout/argument-never-used.stderr
@@ -1,0 +1,7 @@
+error: argument never used
+ --> $DIR/argument-never-used.rs:5:18
+  |
+5 |     println!("", 42);
+  |              --  ^^ argument never used
+  |              |
+  |              formatting specifier missing

--- a/proconio/tests/ui/fastout/format-argument-must-be-a-string-literal.rs
+++ b/proconio/tests/ui/fastout/format-argument-must-be-a-string-literal.rs
@@ -1,0 +1,9 @@
+use proconio::fastout;
+
+#[fastout]
+fn main() {
+    println!(42);
+
+    let x = 42;
+    println!(x);
+}

--- a/proconio/tests/ui/fastout/format-argument-must-be-a-string-literal.stderr
+++ b/proconio/tests/ui/fastout/format-argument-must-be-a-string-literal.stderr
@@ -1,0 +1,21 @@
+error: format argument must be a string literal
+ --> $DIR/format-argument-must-be-a-string-literal.rs:5:14
+  |
+5 |     println!(42);
+  |              ^^
+  |
+help: you might be missing a string literal to format with
+  |
+5 |     println!("{}", 42);
+  |              ^^^^^
+
+error: format argument must be a string literal
+ --> $DIR/format-argument-must-be-a-string-literal.rs:8:14
+  |
+8 |     println!(x);
+  |              ^
+  |
+help: you might be missing a string literal to format with
+  |
+8 |     println!("{}", x);
+  |              ^^^^^

--- a/proconio/tests/ui/fastout/print-macros-in-closures.rs
+++ b/proconio/tests/ui/fastout/print-macros-in-closures.rs
@@ -1,0 +1,6 @@
+use proconio::fastout;
+
+#[fastout]
+fn main() {
+    let _ = || println!("Hi");
+}

--- a/proconio/tests/ui/fastout/print-macros-in-closures.stderr
+++ b/proconio/tests/ui/fastout/print-macros-in-closures.stderr
@@ -1,0 +1,9 @@
+error: Closures in a #[fastout] function cannot contain `print!` or `println!` macro
+
+note: If you want to run your entire logic in a thread having extended size of stack, you can define a new function instead.  See documentation (https://docs.rs/proconio/#closures-having-print-or-println-in-fastout-function) for more details.
+
+note: This is because if you use this closure with `std::thread::spawn()` or any other functions requiring `Send` for an argument closure, the compiler emits an error about thread unsafety for our internal implementations.  If you are using the closure just in a single thread, it's actually no problem, but we cannot check the trait bounds at the macro-expansion time.  So for now, all closures having `print!` or `println!` is prohibited regardless of the `Send` requirements.
+ --> $DIR/print-macros-in-closures.rs:5:16
+  |
+5 |     let _ = || println!("Hi");
+  |                ^^^^^^^

--- a/proconio/tests/ui/fastout/requires-at-least-a-format-string-argument.rs
+++ b/proconio/tests/ui/fastout/requires-at-least-a-format-string-argument.rs
@@ -1,0 +1,6 @@
+use proconio::fastout;
+
+#[fastout]
+fn main() {
+    print!();
+}

--- a/proconio/tests/ui/fastout/requires-at-least-a-format-string-argument.stderr
+++ b/proconio/tests/ui/fastout/requires-at-least-a-format-string-argument.stderr
@@ -1,0 +1,7 @@
+error: requires at least a format string argument
+ --> $DIR/requires-at-least-a-format-string-argument.rs:5:5
+  |
+5 |     print!();
+  |     ^^^^^^^^^ in this macro invocation
+  |
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)


### PR DESCRIPTION
Previously this was allowed

```rust
println!(42); // because `42` is a `literal`
```

and the error message for non literal "format" was unkind for Rust beginners.

```rust
let x = 42;
println!(x);
```

```console
error: no rules expected the token `x`
 --> playground/src/bin/fastout.rs:7:14
  |
3 | #[fastout]
  | ---------- when calling this macro
...
7 |     println!(x);
  |              ^ no rules expected this token in macro call

error: aborting due to previous error
```

The new error message will be:

```console
error: format argument must be a string literal
 --> playground/src/bin/fastout.rs:9:14
  |
9 |     println!(x);
  |              ^
  |
help: you might be missing a string literal to format with
  |
9 |     println!("{}", x);
  |              ^^^^^

error: aborting due to previous error
```

## Other ideas

1. Just change `$fmt:literal` to `$fmt::tt`

    `std::concat!` denies non literal `tt`s.

    ```console
    error: expected a literal
     --> playground/src/bin/fastout.rs:9:14
      |
    9 |     println!(x);
      |              ^
      |
      = note: only literals (like `"foo"`, `42` and `3.14`) can be passed to `concat!()`
    ```

2. Evaluate `std::format_args!($fmt $($rest)*)` somewhere

    ```rust
    if true {
        <::std::io::BufWriter<::std::io::StdoutLock> as ::std::io::Write>::write_fmt(
            &mut __proconio_stdout,
            ::std::format_args!(::std::concat!($fmt, "\n") $($rest)*),
        ).unwrap();
    } else {
        let _ = ::std::format_args!($fmt $($rest)*);
    }
    ```

    A little annoying.

    ```rust
    use proconio::fastout;

    #[fastout]
    fn main() {
        // OK
        let x = 42;
        println!("{}", x);

        // error: expected a literal
        //  --> playground/src/bin/fastout.rs:6:14
        //   |
        // 6 |     println!(x);
        //   |              ^
        //   |
        //   = note: only literals (like `"foo"`, `42` and `3.14`) can be passed to `concat!()`
        //
        // error: format argument must be a string literal
        //  --> playground/src/bin/fastout.rs:6:14
        //   |
        // 6 |     println!(x);
        //   |              ^
        //   |
        // help: you might be missing a string literal to format with
        //   |
        // 6 |     println!("{}", x);
        //   |              ^^^^^
        //
        // error: aborting due to 2 previous errors
        let x = 42;
        println!(x);

        // error: format argument must be a string literal
        //  --> playground/src/bin/fastout.rs:5:14
        //   |
        // 5 |     println!(42);
        //   |              ^^
        //   |
        // help: you might be missing a string literal to format with
        //   |
        // 5 |     println!("{}", 42);
        //   |              ^^^^^
        //
        // error: aborting due to previous error
        println!(42);

        // warning: using `println!("")`
        //  --> playground/src/bin/fastout.rs:5:5
        //   |
        // 5 |     println!("", 42);
        //   |     ^^^^^^^^^^^^^^^^ help: replace it with: `println!()`
        //   |
        //   = note: `#[warn(clippy::println_empty_string)]` on by default
        //   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#println_empty_string
        //
        // error: argument never used
        //  --> playground/src/bin/fastout.rs:5:18
        //   |
        // 3 | #[fastout]
        //   | ---------- formatting specifier missing
        // 4 | fn main() {
        // 5 |     println!("", 42);
        //   |                  ^^ argument never used
        //
        // error: argument never used
        //  --> playground/src/bin/fastout.rs:5:18
        //   |
        // 5 |     println!("", 42);
        //   |              --  ^^ argument never used
        //   |              |
        //   |              formatting specifier missing
        //
        // error: aborting due to 2 previous errors
        //
        // error: could not compile `playground`.
        println!("", 42);

        // error: 1 positional argument in format string, but no arguments were given
        //  --> playground/src/bin/fastout.rs:3:1
        //   |
        // 3 | #[fastout]
        //   | ^^^^^^^^^^
        // 4 | fn main() {
        // 5 |     println!("{}");
        //   |     --------------- in this macro invocation
        //
        // error: 1 positional argument in format string, but no arguments were given
        //  --> playground/src/bin/fastout.rs:5:15
        //   |
        // 5 |     println!("{}");
        //   |               ^^
        //
        // error: aborting due to 2 previous errors
        println!("{}");
    }
    ```
