### PR TITLE
Add interactive_input

### DIFF
--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -44,7 +44,7 @@ required-features = ["derive"]
 harness = false
 
 [dependencies]
-lazy_static = "1.4.0"
+once_cell = "1.12.0"
 
 [dependencies.proconio-derive]
 version = "0.2.0"

--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -18,6 +18,11 @@ path = "tests/stdin.rs"
 harness = false
 
 [[test]]
+name = "interactive"
+path = "tests/interactive.rs"
+harness = false
+
+[[test]]
 name = "derive"
 path = "tests/derive.rs"
 required-features = ["derive"]

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -512,7 +512,7 @@ pub use proconio_derive::*;
 pub mod marker;
 pub mod source;
 
-use crate::source::auto::AutoSource;
+use crate::source::{auto::AutoSource, line::LineSource};
 use lazy_static::lazy_static;
 use std::io;
 use std::io::{BufReader, Stdin};
@@ -526,6 +526,12 @@ lazy_static! {
     #[doc(hidden)]
     pub static ref STDIN_SOURCE: Mutex<AutoSource<BufReader<Stdin>>> =
         Mutex::new(AutoSource::new(BufReader::new(io::stdin())));
+}
+
+lazy_static! {
+    #[doc(hidden)]
+    pub static ref INTERACTIVE_STDIN_SOURCE: Mutex<AutoSource<BufReader<Stdin>>> =
+        Mutex::new(LineSource::new(BufReader::new(io::stdin())));
 }
 
 /// read input from stdin.
@@ -603,6 +609,35 @@ macro_rules! input {
         $crate::input! {
             @from [&mut *locked_stdin]
             @rest $($rest)*
+        }
+        drop(locked_stdin); // release the lock
+    };
+}
+
+/// read input from stdin interactively.
+///
+/// this macro is alias of:
+/// ```text
+/// let source = procontio::source::line::LineSource::new(BufReader::new(std::io::stdin()))
+/// input! {
+///     from &mut source,
+///     (mut) variable: type,
+///     ...
+/// }
+/// ```
+/// read the documet of [input!](input) for further information.
+#[macro_export]
+macro_rules! input_interactive {
+    ($($rest:tt)*) => {
+        let mut locked_stdin = $crate::INTERACTIVE_STDIN_SOURCE.lock().expect(concat!(
+            "failed to lock the stdin; please re-run this program.  ",
+            "If this issue repeatedly occur, this is a bug in `proconio`.  ",
+            "Please report this issue from ",
+            "<https://github.com/statiolake/proconio-rs/issues>."
+        ));
+        $crate::input! {
+            from &mut *locked_stdin,
+            $($rest)*
         }
         drop(locked_stdin); // release the lock
     };

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -513,26 +513,44 @@ pub mod marker;
 pub mod source;
 
 use crate::source::{auto::AutoSource, line::LineSource};
-use lazy_static::lazy_static;
-use std::io;
+use once_cell::sync::OnceCell;
 use std::io::{BufReader, Stdin};
-use std::sync::Mutex;
+use std::{
+    io::{self, BufRead},
+    sync::Mutex,
+};
 
 // Prepares a short path to `Readable` to enables rust-analyzer to infer `Readable::Output`.
 #[doc(hidden)]
 pub use crate::source::Readable as __Readable;
 
-lazy_static! {
-    #[doc(hidden)]
-    pub static ref STDIN_SOURCE: Mutex<AutoSource<BufReader<Stdin>>> =
-        Mutex::new(AutoSource::new(BufReader::new(io::stdin())));
+pub enum StdinSource<R: BufRead> {
+    Normal(AutoSource<R>), // for input!
+    Interactive(LineSource<R>), // for for input_interactive!
+    Unknown(LineSource<R>), // for is_stdin_empty() without input! or input_interactive!
 }
 
-lazy_static! {
-    #[doc(hidden)]
-    pub static ref INTERACTIVE_STDIN_SOURCE: Mutex<LineSource<BufReader<Stdin>>> =
-        Mutex::new(LineSource::new(BufReader::new(io::stdin())));
+impl<R: BufRead> source::Source<R> for StdinSource<R> {
+    fn next_token(&mut self) -> Option<&str> {
+        match self {
+            StdinSource::Normal(source) => source.next_token(),
+            StdinSource::Interactive(source) => source.next_token(),
+            StdinSource::Unknown(source) => source.next_token(),
+        }
+    }
+
+    fn is_empty(&mut self) -> bool {
+        match self {
+            StdinSource::Normal(source) => source.is_empty(),
+            StdinSource::Interactive(source) => source.is_empty(),
+            StdinSource::Unknown(source) => source.is_empty(),
+        }
+
+    }
 }
+
+#[doc(hidden)]
+pub static STDIN_SOURCE: OnceCell<Mutex<StdinSource<BufReader<Stdin>>>> = OnceCell::new();
 
 /// read input from stdin.
 ///
@@ -600,12 +618,19 @@ macro_rules! input {
         }
     };
     ($($rest:tt)*) => {
-        let mut locked_stdin = $crate::STDIN_SOURCE.lock().expect(concat!(
-            "failed to lock the stdin; please re-run this program.  ",
-            "If this issue repeatedly occur, this is a bug in `proconio`.  ",
-            "Please report this issue from ",
-            "<https://github.com/statiolake/proconio-rs/issues>."
-        ));
+        let mut locked_stdin = $crate::STDIN_SOURCE
+            .get_or_init(|| {
+                std::sync::Mutex::new($crate::StdinSource::Normal(
+                    $crate::source::auto::AutoSource::new(std::io::BufReader::new(std::io::stdin())),
+                ))
+            })
+            .lock()
+            .expect(concat!(
+                "failed to lock the stdin; please re-run this program.  ",
+                "If this issue repeatedly occur, this is a bug in `proconio`.  ",
+                "Please report this issue from ",
+                "<https://github.com/statiolake/proconio-rs/issues>."
+            ));
         $crate::input! {
             @from [&mut *locked_stdin]
             @rest $($rest)*
@@ -629,12 +654,19 @@ macro_rules! input {
 #[macro_export]
 macro_rules! input_interactive {
     ($($rest:tt)*) => {
-        let mut locked_stdin = $crate::INTERACTIVE_STDIN_SOURCE.lock().expect(concat!(
-            "failed to lock the stdin; please re-run this program.  ",
-            "If this issue repeatedly occur, this is a bug in `proconio`.  ",
-            "Please report this issue from ",
-            "<https://github.com/statiolake/proconio-rs/issues>."
-        ));
+        let mut locked_stdin = $crate::STDIN_SOURCE
+            .get_or_init(|| {
+                std::sync::Mutex::new($crate::StdinSource::Interactive(
+                    $crate::source::line::LineSource::new(std::io::BufReader::new(std::io::stdin())),
+                ))
+            })
+            .lock()
+            .expect(concat!(
+                "failed to lock the stdin; please re-run this program.  ",
+                "If this issue repeatedly occur, this is a bug in `proconio`.  ",
+                "Please report this issue from ",
+                "<https://github.com/statiolake/proconio-rs/issues>."
+            ));
         $crate::input! {
             from &mut *locked_stdin,
             $($rest)*
@@ -712,24 +744,20 @@ macro_rules! read_value {
 /// }
 /// ```
 pub fn is_stdin_empty() -> bool {
-    use crate::source::Source;
-    let mut lock = STDIN_SOURCE.lock().expect(concat!(
-        "failed to lock the stdin; please re-run this program.  ",
-        "If this issue repeatedly occur, this is a bug in `proconio`.  ",
-        "Please report this issue from ",
-        "<https://github.com/statiolake/proconio-rs/issues>."
-    ));
-    lock.is_empty()
-}
-
-pub fn is_stdin_empty_interactive() -> bool {
-    use crate::source::Source;
-    let mut lock = INTERACTIVE_STDIN_SOURCE.lock().expect(concat!(
-        "failed to lock the stdin; please re-run this program.  ",
-        "If this issue repeatedly occur, this is a bug in `proconio`.  ",
-        "Please report this issue from ",
-        "<https://github.com/statiolake/proconio-rs/issues>."
-    ));
+    use source::Source;
+    let mut lock = STDIN_SOURCE
+        .get_or_init(|| {
+            Mutex::new(StdinSource::Unknown(LineSource::new(BufReader::new(
+                io::stdin(),
+            ))))
+        })
+        .lock()
+        .expect(concat!(
+            "failed to lock the stdin; please re-run this program.  ",
+            "If this issue repeatedly occur, this is a bug in `proconio`.  ",
+            "Please report this issue from ",
+            "<https://github.com/statiolake/proconio-rs/issues>."
+        ));
     lock.is_empty()
 }
 

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -525,9 +525,9 @@ use std::{
 pub use crate::source::Readable as __Readable;
 
 pub enum StdinSource<R: BufRead> {
-    Normal(AutoSource<R>), // for input!
+    Normal(AutoSource<R>),      // for input!
     Interactive(LineSource<R>), // for for input_interactive!
-    Unknown(LineSource<R>), // for is_stdin_empty() without input! or input_interactive!
+    Unknown(LineSource<R>),     // for is_stdin_empty() without input! or input_interactive!
 }
 
 impl<R: BufRead> source::Source<R> for StdinSource<R> {
@@ -545,7 +545,6 @@ impl<R: BufRead> source::Source<R> for StdinSource<R> {
             StdinSource::Interactive(source) => source.is_empty(),
             StdinSource::Unknown(source) => source.is_empty(),
         }
-
     }
 }
 

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -530,7 +530,7 @@ lazy_static! {
 
 lazy_static! {
     #[doc(hidden)]
-    pub static ref INTERACTIVE_STDIN_SOURCE: Mutex<AutoSource<BufReader<Stdin>>> =
+    pub static ref INTERACTIVE_STDIN_SOURCE: Mutex<LineSource<BufReader<Stdin>>> =
         Mutex::new(LineSource::new(BufReader::new(io::stdin())));
 }
 

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -722,6 +722,17 @@ pub fn is_stdin_empty() -> bool {
     lock.is_empty()
 }
 
+pub fn is_stdin_empty_interactive() -> bool {
+    use crate::source::Source;
+    let mut lock = INTERACTIVE_STDIN_SOURCE.lock().expect(concat!(
+        "failed to lock the stdin; please re-run this program.  ",
+        "If this issue repeatedly occur, this is a bug in `proconio`.  ",
+        "Please report this issue from ",
+        "<https://github.com/statiolake/proconio-rs/issues>."
+    ));
+    lock.is_empty()
+}
+
 #[cfg(test)]
 mod tests {
     use crate::source::auto::AutoSource;

--- a/proconio/src/source/mod.rs
+++ b/proconio/src/source/mod.rs
@@ -77,6 +77,7 @@ pub trait Source<R: BufRead> {
     fn next_token(&mut self) -> Option<&str>;
 
     /// Check if tokens are empty
+    #[allow(clippy::wrong_self_convention)]
     fn is_empty(&mut self) -> bool;
 
     /// Force gets a whitespace-splitted next token.

--- a/proconio/tests/interactive.rs
+++ b/proconio/tests/interactive.rs
@@ -5,27 +5,27 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
 // distributed except according to those terms.
 
-use proconio::{input_interactive as input, is_stdin_empty};
+use proconio::{input_interactive, is_stdin_empty_interactive};
 
 fn test_stdin() {
-    assert!(!is_stdin_empty());
-    input! {
+    assert!(!is_stdin_empty_interactive());
+    input_interactive! {
         n: usize,
     }
-    assert!(!is_stdin_empty());
+    assert!(!is_stdin_empty_interactive());
     println!("{}", n);
 
     for c in 0..n {
         println!("start {}", c);
-        assert!(!is_stdin_empty());
-        input! {
+        assert!(!is_stdin_empty_interactive());
+        input_interactive! {
             i: isize,
             j: isize,
         }
 
         println!("{} {}", i, j);
     }
-    assert!(is_stdin_empty());
+    assert!(is_stdin_empty_interactive());
 }
 
 fn test_for(input: &str, expected_stdout: &str) {

--- a/proconio/tests/interactive.rs
+++ b/proconio/tests/interactive.rs
@@ -5,19 +5,19 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
 // distributed except according to those terms.
 
-use proconio::{input_interactive, is_stdin_empty_interactive};
+use proconio::{input_interactive, is_stdin_empty};
 
 fn test_stdin() {
-    assert!(!is_stdin_empty_interactive());
+    assert!(!is_stdin_empty());
     input_interactive! {
         n: usize,
     }
-    assert!(!is_stdin_empty_interactive());
+    assert!(!is_stdin_empty());
     println!("{}", n);
 
     for c in 0..n {
         println!("start {}", c);
-        assert!(!is_stdin_empty_interactive());
+        assert!(!is_stdin_empty());
         input_interactive! {
             i: isize,
             j: isize,
@@ -25,7 +25,7 @@ fn test_stdin() {
 
         println!("{} {}", i, j);
     }
-    assert!(is_stdin_empty_interactive());
+    assert!(is_stdin_empty());
 }
 
 fn test_for(input: &str, expected_stdout: &str) {

--- a/proconio/tests/interactive.rs
+++ b/proconio/tests/interactive.rs
@@ -1,0 +1,55 @@
+// Copyright 2019 statiolake <statiolake@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
+// distributed except according to those terms.
+
+use proconio::{input_interactive as input, is_stdin_empty};
+
+fn test_stdin() {
+    assert!(!is_stdin_empty());
+    input! {
+        n: usize,
+    }
+    assert!(!is_stdin_empty());
+    println!("{}", n);
+
+    for c in 0..n {
+        println!("start {}", c);
+        assert!(!is_stdin_empty());
+        input! {
+            i: isize,
+            j: isize,
+        }
+
+        println!("{} {}", i, j);
+    }
+    assert!(is_stdin_empty());
+}
+
+fn test_for(input: &str, expected_stdout: &str) {
+    use assert_cli::Assert;
+    use std::env::args;
+    Assert::command(&[&*args().next().unwrap(), "foo"])
+        .stdin(input)
+        .stdout()
+        .is(expected_stdout)
+        .and()
+        .stderr()
+        .is("")
+        .unwrap();
+}
+
+fn main() {
+    use std::env::args;
+    if args().len() == 1 {
+        test_for(
+            "3\n1 2\n3 4\n5 6\n",
+            "3\nstart 0\n1 2\nstart 1\n3 4\nstart 2\n5 6\n",
+        );
+        return;
+    }
+
+    test_stdin();
+}


### PR DESCRIPTION
Fix #26

I added a macro input_interactive! and a static variable explicitly specified to use `LineSource`.

Also, I have confirmed that input_interactive! works correctly with a AtCoder's interactive problem (https://atcoder.jp/contests/abc244/tasks/abc244_c).

using input! is TLE.
https://atcoder.jp/contests/abc244/submissions/31939069

using input_interactive! is AC.
https://atcoder.jp/contests/abc244/submissions/31939061

Besides, I found a trivial clippy lint warning and fixed it.