### PR TITLE
Freeze some library version to stop error on Rust 1.42.0

### DIFF
--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -44,7 +44,8 @@ required-features = ["derive"]
 harness = false
 
 [dependencies]
-once_cell = "1.12.0"
+# 1.15.0 uses Rust 2021 edition; does not compile on Rust 1.42.
+once_cell = "=1.14.0"
 
 [dependencies.proconio-derive]
 version = "0.2.0"

--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -54,7 +54,7 @@ optional = true
 
 [dev-dependencies]
 rustversion = "1.0.2"
-trybuild = "1.0.24"
+trybuild = "=1.0.67"
 assert_cli = "0.6.3"
 
 [features]


### PR DESCRIPTION
From 1.15.0, once_cell enables Rust 2021 edition. It does not compile on current AtCoder target, 1.42.0.