### PR TITLE
Add warning for incompatibility with AtCoder 202004

### DIFF
--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -59,3 +59,4 @@ assert_cli = "0.6.3"
 
 [features]
 derive = ["proconio-derive"]
+disable_compat_warning = []

--- a/proconio/README.md
+++ b/proconio/README.md
@@ -5,7 +5,7 @@
 
 Easy IO library for competitive programming.
 
-`proconio` provides an easy way to read values from stdin (or other source).  The main is `input!` macro.
+`proconio` provides an easy way to read values from stdin (or other source). The main is `input!` macro.
 
 The macro's user interface is basically the same with [tanakh's input macro](https://qiita.com/tanakh/items/0ba42c7ca36cd29d0ac8).
 
@@ -23,3 +23,14 @@ println!("{} {} {}", n, m, l);
 ```
 
 For more details, see documentation.
+
+- [Documentation for latest v0.3](https://docs.rs/proconio/0.3)  
+  v0.3.x is AtCoder 2020 compatible version.
+- [Documentation for latest version](https://docs.rs/proconio)  
+  The latest version containing new features and bug fixes.
+
+## AtCoder 2020 compatibility
+
+The latest version (v0.4.x) has some incompatible new features and bug fixes
+with the version in AtCoder 2020 judge server. We strongly recommend that you
+use v0.3.x in your local environment too.

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -506,6 +506,9 @@
 //! If you don't like this behavior, you can remove #[fastout] from your `main()`.
 //!
 
+/// Module to emit warnings in unsupported environments.
+mod warning;
+
 #[cfg(feature = "derive")]
 pub use proconio_derive::*;
 

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -505,6 +505,56 @@
 //!
 //! If you don't like this behavior, you can remove `#[fastout]` from your `main()`.
 //!
+//! # AtCoder compatibility warning
+//!
+//! You may see the following warning during compiling your program:
+//!
+//! ```console
+//! warning: use of deprecated constant `warning::_::WARN`: this version of proconio is not compatible
+//!          please use the v0.3.x version instead if you use this in the AtCoder 2020 update.
+//!          note: for uses outside of AtCoder, you can disable this warning via the `disable_compat_warning` feature.
+//!  --> proconio/src/warning.rs:6:6
+//!   |
+//! 6 |     (WARN, "please use proconio v0.3.x in AtCoder 2020");
+//!   |      ^^^^
+//!   |
+//!   = note: `#[warn(deprecated)]` on by default
+//! ```
+//!
+//! This is because the version you are using (v0.4.x) is not compatible with AtCoder 2020:
+//!
+//! - Some new features are added, so you may get Compile Error (CE) while your local test
+//!   successfully compiles.
+//! - Some bug fixes not compatible with v0.3.x are included, so you may encounter the unexpected
+//!   Runtime Error (RE) on server while your local test successfully passes.
+//!   One of the serious bugs is issue [#8](https://github.com/statiolake/proconio-rs/issues/8) or
+//!   [#14](https://github.com/statiolake/proconio-rs/issues/14).
+//!
+//! In order to avoid wasting time during contest to solve such a hard-to-notice problems, we
+//! strongly recommend that you use v0.3.x versions for AtCoder 2020 in your local environment too.
+//! The latest v0.3.x is almost same with the version used in the AtCoder, but guards to some bugs
+//! are added. For example, code that may cause above bug
+//! [#8](https://github.com/statiolake/proconio-rs/issues/8) in server is compile-time error in the
+//! latest v0.3.x version. We will add such warnings when we find another bug.
+//!
+//! ## Disable warning
+//!
+//! If you are not intended to use proconio with AtCoder 2020, you may disable the warning by
+//! enabling feature `disable_compat_warning`. Features can be enabled by modifying dependency
+//! section in Cargo.toml of your project to:
+//!
+//! ```toml
+//! [dependencies.proconio]
+//! version = "0.4"
+//! features = ["disable_compat_warning"] # Add this
+//! ```
+//!
+//! or
+//!
+//! ```toml
+//! [dependencies]
+//! proconio = { version = "0.4", features = ["disable_compat_warning"] }
+//! ```
 
 /// Module to emit warnings in unsupported environments.
 mod warning;

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -503,7 +503,7 @@
 //! world
 //! ```
 //!
-//! If you don't like this behavior, you can remove #[fastout] from your `main()`.
+//! If you don't like this behavior, you can remove `#[fastout]` from your `main()`.
 //!
 
 /// Module to emit warnings in unsupported environments.

--- a/proconio/src/warning.rs
+++ b/proconio/src/warning.rs
@@ -1,0 +1,15 @@
+#![allow(path_statements, clippy::no_effect)]
+
+#[cfg(not(feature = "disable_compat_warning"))]
+const _: () = {
+    #[rustfmt::skip]
+    (WARN, "please use proconio v0.3.x in AtCoder 2020");
+
+    #[deprecated(note = "this version of proconio is not compatible\n\
+        please use the v0.3.x version instead \
+        if you use this in the AtCoder 2020 update.\n\
+        note: for uses outside of AtCoder, \
+        you can disable this warning \
+        via the `disable_compat_warning` feature.")]
+    const WARN: () = ();
+};


### PR DESCRIPTION
This version (v0.4.x currently) is not compatible with version included in AtCoder 202004 update. Some differences like below is especially problematic, as it may cause different behavior between server and local which can results in `Compile Error`s.

- #[fastout] is now fixed
  use in `match` can produce different printing order. Expected result on local environment, wrong on server.
- input_interactive! is added

To prevent users from unexpectedly run into those problems, add the warning by default. This warning can be disabled by `disable_compat_warning`.

Closes #35.