### PR TITLE
Drop consumed context explicitly

### DIFF
--- a/proconio/src/source/tokens.rs
+++ b/proconio/src/source/tokens.rs
@@ -64,6 +64,6 @@ impl Drop for CurrentContext {
         // # Safety
         //
         // The pointee should be no longer refferred.
-        unsafe { Box::from_raw(self.0.as_mut()) };
+        unsafe { drop(Box::from_raw(self.0.as_mut())) };
     }
 }


### PR DESCRIPTION
It seems that clippy became to warn unused result in Box::from_raw() from Rust 1.72.