### PR TITLE
Allow type with more than one generic arg

### DIFF
--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -604,8 +604,17 @@ macro_rules! input {
         $crate::input!(@from [$source] @mut [$($mut)*] @var $var @kind [$($kind)*] @rest);
         $crate::input!(@from [$source] @rest $($rest)*);
     };
-    (@from [$source:expr] @mut [$($mut:tt)?] @var $var:tt @kind [$($kind:tt)*] @rest $tt:tt $($rest:tt)*) => {
-        $crate::input!(@from [$source] @mut [$($mut)*] @var $var @kind [$($kind)* $tt] @rest $($rest)*);
+    (@from [$source:expr] @mut [$($mut:tt)?] @var $var:tt @kind [] @rest [$($tt:tt)*] $($rest:tt)*) => {
+        $crate::input!(@from [$source] @mut [$($mut)*] @var $var @kind [[$($tt)*]] @rest $($rest)*);
+    };
+    (@from [$source:expr] @mut [$($mut:tt)?] @var $var:tt @kind [] @rest ($($tt:tt)*) $($rest:tt)*) => {
+        $crate::input!(@from [$source] @mut [$($mut)*] @var $var @kind [($($tt)*)] @rest $($rest)*);
+    };
+    (@from [$source:expr] @mut [$($mut:tt)?] @var $var:tt @kind [] @rest $ty:ty, $($rest:tt)*) => {
+        $crate::input!(@from [$source] @mut [$($mut)*] @var $var @kind [$ty] @rest, $($rest)*);
+    };
+    (@from [$source:expr] @mut [$($mut:tt)?] @var $var:tt @kind [] @rest $ty:ty) => {
+        $crate::input!(@from [$source] @mut [$($mut)*] @var $var @kind [$ty] @rest);
     };
 
     (from $source:expr, $($rest:tt)*) => {
@@ -978,6 +987,35 @@ mod tests {
         assert_eq!(n, 3);
         assert_eq!(k, 43);
         assert_eq!(xs, [1, 2, 3]);
+    }
+
+    #[test]
+    fn input_generic() {
+        enum Array<T, const N: usize> {
+            _Phantom(
+                std::convert::Infallible,
+                std::marker::PhantomData<fn() -> T>,
+            ),
+        }
+
+        impl<T: crate::source::Readable, const N: usize> crate::source::Readable for Array<T, N> {
+            type Output = [T::Output; N];
+
+            fn read<R: std::io::BufRead, S: crate::source::Source<R>>(source: &mut S) -> Self::Output {
+                std::array::from_fn(|_| T::read(source))
+            }
+        }
+
+        let source = AutoSource::from("1 2 3 4 5 6 7 8");
+
+        input! {
+            from source,
+            a: Array<i32, 5>,
+            b: Array<i32, 3>,
+        }
+
+        assert_eq!(a, [1, 2, 3, 4, 5]);
+        assert_eq!(b, [6, 7, 8]);
     }
 
     #[test]

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -1001,7 +1001,9 @@ mod tests {
         impl<T: crate::source::Readable, const N: usize> crate::source::Readable for Array<T, N> {
             type Output = [T::Output; N];
 
-            fn read<R: std::io::BufRead, S: crate::source::Source<R>>(source: &mut S) -> Self::Output {
+            fn read<R: std::io::BufRead, S: crate::source::Source<R>>(
+                source: &mut S,
+            ) -> Self::Output {
                 std::array::from_fn(|_| T::read(source))
             }
         }


### PR DESCRIPTION
I noticed that we can't use generic types with two or more arguments for the `@kind` part of the `input!` macro.
This is, IIUC, bacause the comma `,` that separates generic arguments is treated as a comma that separates fields in `input!` macro, and thus `read_value!` gets something like `@kind Foo<Arg1 `.

To fix the issue, I had to special-case vec type `[...]` and tuple type `(...)` inside the `input!` macro and fall-through to `ty` instead of `tt*`, since once the whole `[...]`/`(..)` are matched to `ty` it can't be matched to `[ tt* ]` / `( tt* )` in `read_value!` macro, it seems to me. (see: https://doc.rust-lang.org/nightly/reference/macros-by-example.html#forwarding-a-matched-fragment )

Disclaimer: I'm noob at macros, and not 100% confident with the change. Please read the change with a skeptical eye :pray: