### PR TITLE
Remove usage of legacy constant

### DIFF
--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -930,7 +930,7 @@ mod tests {
     #[should_panic]
     fn input_min_as_isize1() {
         use crate::marker::Isize1;
-        let min_string = std::isize::MIN.to_string();
+        let min_string = isize::MIN.to_string();
         let mut source = AutoSource::from(&*min_string);
         input! {
             from &mut source,

--- a/proconio/src/marker.rs
+++ b/proconio/src/marker.rs
@@ -58,7 +58,7 @@ impl Readable for Isize1 {
                     "attempted to read the value {} as a Isize1:",
                     " the value is isize::MIN and cannot be decremented"
                 ),
-                std::isize::MIN,
+                isize::MIN,
             )
         })
     }


### PR DESCRIPTION
As of 2024-04-29, the legacy integer constant (`std::isize::MIN`) causes an error in the beta channel.