### PR TITLE
Add run-time version of Readable

### DIFF
--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -768,7 +768,7 @@ macro_rules! read_value {
 
     // dynamic readable
     (@source [$source:expr] @dyn_kind [$dyn_kind:expr]) => {
-        $dyn_kind.read($source)
+        $crate::source::DynamicReadable::read($dyn_kind, $source)
     };
 
     // unreachable

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -596,7 +596,7 @@ macro_rules! input {
         }
     };
 
-    // parse `with` (the marker of DynamicReadable type)
+    // parse `with` (the marker of RuntimeReadable type)
     (@from [$source:expr] @mut [$($mut:tt)?] @var $var:tt @kind [] @rest with $($rest:tt)*) => {
         $crate::input! {
             @from [$source]
@@ -628,7 +628,7 @@ macro_rules! input {
         $crate::input!(@from [$source] @mut [$($mut)*] @var $var @kind [$ty] @rest);
     };
 
-    // parse dynamic kind (DynamicReadable type)
+    // parse runtime kind (RuntimeReadable type)
     (@from [$source:expr] @mut [$($mut:tt)?] @var $var:tt @dyn_kind [$($dyn_kind:tt)*] @rest) => {
         let $($mut)* $var = $crate::read_value!(@source [$source] @dyn_kind [$($dyn_kind)*]);
     };
@@ -766,9 +766,9 @@ macro_rules! read_value {
         <$kind as $crate::__Readable>::read($source)
     };
 
-    // dynamic readable
+    // runtime readable
     (@source [$source:expr] @dyn_kind [$dyn_kind:expr]) => {
-        $crate::source::DynamicReadable::read($dyn_kind, $source)
+        $crate::source::RuntimeReadable::read($dyn_kind, $source)
     };
 
     // unreachable
@@ -1068,7 +1068,7 @@ mod tests {
     }
 
     #[test]
-    fn input_dynamic_readable() {
+    fn input_runtime_readable() {
         // VecReadable<T> replicates the built-in Vec reader `input!(v: [T])` in user-land.
         struct VecReadable<T> {
             n: usize,
@@ -1084,7 +1084,7 @@ mod tests {
             }
         }
 
-        impl<T: crate::source::Readable> crate::source::DynamicReadable for VecReadable<T> {
+        impl<T: crate::source::Readable> crate::source::RuntimeReadable for VecReadable<T> {
             type Output = Vec<T::Output>;
 
             fn read<R: std::io::BufRead, S: crate::source::Source<R>>(

--- a/proconio/src/source/mod.rs
+++ b/proconio/src/source/mod.rs
@@ -152,11 +152,11 @@ where
 /// # use proconio::marker::Usize1;
 /// # use std::io::BufRead;
 /// struct DirectedGraph(usize, usize);
-/// impl DynamicReadable for &DirectedGraph {
+/// impl DynamicReadable for DirectedGraph {
 ///     type Output = Vec<Vec<usize>>;
 ///
 ///     fn read<R: BufRead, S: Source<R>>(self, source: &mut S) -> Self::Output {
-///         let DirectedGraph(n, m) = *self;
+///         let DirectedGraph(n, m) = self;
 ///
 ///         input! {
 ///             from source,

--- a/proconio/src/source/mod.rs
+++ b/proconio/src/source/mod.rs
@@ -139,20 +139,18 @@ where
     }
 }
 
-/// A trait representing which type can be read from `Source` dynamically.
-///
-/// You can define your own type which dynamically changes how to read the value, such as a directed
-/// graph that the number of nodes is given in the prior inputs.
+/// A trait that specifies how to read a value of some type from `Source` in such a way that is only
+/// known at runtime, such as reading a vector or graph whose size is specified at runtime.
 ///
 /// ```
-/// # use proconio::source::DynamicReadable;
+/// # use proconio::source::RuntimeReadable;
 /// # use proconio::source::auto::AutoSource;
 /// # use proconio::source::Source;
 /// # use proconio::input;
 /// # use proconio::marker::Usize1;
 /// # use std::io::BufRead;
 /// struct DirectedGraph(usize, usize);
-/// impl DynamicReadable for DirectedGraph {
+/// impl RuntimeReadable for DirectedGraph {
 ///     type Output = Vec<Vec<usize>>;
 ///
 ///     fn read<R: BufRead, S: Source<R>>(self, source: &mut S) -> Self::Output {
@@ -179,7 +177,7 @@ where
 ///     g: with DirectedGraph(n, m),
 /// }
 /// ```
-pub trait DynamicReadable {
+pub trait RuntimeReadable {
     type Output;
     fn read<R: BufRead, S: Source<R>>(self, source: &mut S) -> Self::Output;
 }

--- a/proconio/src/source/mod.rs
+++ b/proconio/src/source/mod.rs
@@ -138,3 +138,48 @@ where
         }
     }
 }
+
+/// A trait representing which type can be read from `Source` dynamically.
+///
+/// You can define your own type which dynamically changes how to read the value, such as a directed
+/// graph that the number of nodes is given in the prior inputs.
+///
+/// ```
+/// # use proconio::source::DynamicReadable;
+/// # use proconio::source::auto::AutoSource;
+/// # use proconio::source::Source;
+/// # use proconio::input;
+/// # use proconio::marker::Usize1;
+/// # use std::io::BufRead;
+/// struct DirectedGraph(usize, usize);
+/// impl DynamicReadable for &DirectedGraph {
+///     type Output = Vec<Vec<usize>>;
+///
+///     fn read<R: BufRead, S: Source<R>>(self, source: &mut S) -> Self::Output {
+///         let DirectedGraph(n, m) = *self;
+///
+///         input! {
+///             from source,
+///             edges: [(Usize1, Usize1); m],
+///         };
+///
+///         let mut g = vec![vec![]; n];
+///         for e in edges {
+///             g[e.0].push(e.1);
+///         }
+///         g
+///     }
+/// }
+///
+/// # let mut source = AutoSource::from("2 3\n1 1\n1 2\n2 2\n");
+/// input! {
+/// #   from source,
+///     n: usize,
+///     m: usize,
+///     g: with DirectedGraph(n, m),
+/// }
+/// ```
+pub trait DynamicReadable {
+    type Output;
+    fn read<R: BufRead, S: Source<R>>(self, source: &mut S) -> Self::Output;
+}


### PR DESCRIPTION
Currently, you cannot define the readable which uses the prior inputs or run-time values to determine how to parse the input. That means you can't define user-defined version of built-in `[T]` or `[T; n]`, which uses the prior input as its length.

This feature, `RuntimeReadable`, allows you to define such a readable. For example, you can define a readable for your directed graph:

```rust
struct DirectedGraphReadable(usize, usize);

impl RuntimeReadable for DirectedGraphReadable {
    type Output = Vec<Vec<usize>>;

    fn read<R: BufRead, S: Source<R>>(self, source: &mut S) -> Self::Output {
        let DirectedGraphReadable(n, m) = self;

        input! {
            from source,
            edges: [(Usize1, Usize1); m],
        };

        let mut g = vec![vec![]; n];
        for e in edges {
            g[e.0].push(e.1);
        }
        g
    }
}

let mut source = AutoSource::from("2 3\n1 1\n1 2\n2 2\n");
input! {
  from source,
    n: usize,
    m: usize,
    g: with DirectedGraphReadable(n, m),
}
```

As you can see in the above snippet, you need to specify the runtime readable after `with` for the RuntimeReadable.

Closes #48