### PR TITLE
Add user-friendly version of read_value! macro

### DIFF
--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -555,7 +555,6 @@ pub static STDIN_SOURCE: OnceLock<Mutex<StdinSource<BufReader<Stdin>>>> = OnceLo
 ///
 /// Basic syntax is:
 ///
-/// basic syntax is:
 /// ```text
 /// input! {
 ///     from source,          // optional: if you omitted, stdin is used by default.
@@ -564,7 +563,8 @@ pub static STDIN_SOURCE: OnceLock<Mutex<StdinSource<BufReader<Stdin>>>> = OnceLo
 ///     ...
 /// }
 /// ```
-/// the trailing comma is optional.  `source` can be anything implementing `Source`.  This macro
+///
+/// The trailing comma is optional.  `source` can be anything implementing `Source`.  This macro
 /// moves out the specified source.  If you want to prevent moving, you can use `&mut source` since
 /// `&mut S` where `S: Source` also implements `Source`.
 #[macro_export]
@@ -685,9 +685,10 @@ macro_rules! input {
     };
 }
 
-/// Read input from specified source interactively.
+/// Interactive version of input! macro.
 ///
-/// This macro is an alias of:
+/// This macro is effectively an alias of:
+///
 /// ```text
 /// let source = procontio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
 /// input! {
@@ -696,7 +697,10 @@ macro_rules! input {
 ///     ...
 /// }
 /// ```
-/// read the document of [input!](input) for further information.
+///
+/// With this macro, you always read inputs line-by-line. You can use this as a drop-in replacement
+/// for input! macro in interactive problems. Other than that, usage are the same with input! macro.
+/// Read the document of [input!](input) for further information.
 #[macro_export]
 macro_rules! input_interactive {
     ($($rest:tt)*) => {
@@ -835,7 +839,9 @@ macro_rules! read_value {
 /// let variable = read_value!(from &mut source, type);
 /// ```
 ///
-/// Read the document of [read_value!](read_value) for further information.
+/// With this macro, you always read inputs line-by-line. You can use this as a drop-in replacement
+/// for read_value! macro in interactive problems. Other than that, usage are the same with
+/// read_value! macro. Read the document of [read_value!](read_value) for further information.
 #[macro_export]
 macro_rules! read_value_interactive {
     ($($rest:tt)*) => {

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -9,8 +9,9 @@
 
 //! Easy IO library for competitive programming.
 //!
-//! `proconio` provides an easy way to read values from stdin (or other source).  The main is
-//! `input!` macro.
+//! `proconio` provides an easy way to read values from stdin (or other source).  The main feature
+//! provided by this crate is `input!` macro (and its family, `input_interactive!`, `read_value!`,
+//! and `read_value_interactive!`).
 //!
 //! # Examples
 //!
@@ -295,6 +296,35 @@
 //! # }
 //! ```
 //!
+//! # `read_value!` macro
+//!
+//! `read_value!` macro is a macro used inside the `input!` macro, but using it directly is also
+//! useful in some cases. Typically when you don't need to store the value into a variable.
+//!
+//! ```rust
+//! # extern crate proconio;
+//! use proconio::source::auto::AutoSource;
+//! use proconio::read_value;
+//! let mut source = AutoSource::from("2 3 4");
+//! let mut sum = 0;
+//! for _ in 0..read_value!(from &mut source, usize) {
+//!     sum += read_value!(from &mut source, u32);
+//! }
+//! assert_eq!(sum, 7);
+//! ```
+//!
+//! # Interactive version
+//!
+//! The normal `input!` and `read_value!` macro reads the entire input at once in judge environment
+//! to optimize I/O performance. However this does not work well with interactive problems, since
+//! in those problems you need to communicate with the judge by writing and reading alternately.
+//!
+//! In this case, you can manually create LineSource for stdin. There's handy interactive version of
+//! the macros doing exactly that. They are `input_interactive!` and `read_value_interactive!`.
+//!
+//! The usage of those macros are exactly the same with the normal ones. Refer to the document of
+//! [input!](input) and [read_value!](read_value) for further information.
+//!
 //! # `#[fastout]`
 //!
 //! If you import `proconio::fastout`, you can use `#[fastout]` attribute.  Adding this attribute
@@ -503,7 +533,7 @@
 //! world
 //! ```
 //!
-//! If you don't like this behavior, you can remove #[fastout] from your `main()`.
+//! If you don't like this behavior, you can remove `#[fastout]` from your `main()`.
 //!
 
 #[cfg(feature = "derive")]

--- a/proconio/tests/read_value.rs
+++ b/proconio/tests/read_value.rs
@@ -1,0 +1,40 @@
+// Copyright 2019 statiolake <statiolake@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
+// distributed except according to those terms.
+
+use proconio::read_value;
+
+fn test_stdin() {
+    let mut sum = 0;
+    for _ in 0..read_value!(usize) {
+        sum += read_value!(u32);
+    }
+    println!("{}", sum);
+}
+
+fn test_for(input: &str, expected_stdout: &str) {
+    use assert_cli::Assert;
+    use std::env::args;
+    println!("{:?}", args().next().unwrap());
+    Assert::command(&[&*args().next().unwrap(), "foo"])
+        .stdin(input)
+        .stdout()
+        .is(expected_stdout)
+        .and()
+        .stderr()
+        .is("")
+        .unwrap();
+}
+
+fn main() {
+    use std::env::args;
+    if args().len() == 1 {
+        test_for("2 3 7\n", "10\n");
+        return;
+    }
+
+    test_stdin();
+}


### PR DESCRIPTION
Currently, `read_value!` macro is just an internal implementation. In this PR, we expose read_value! macro with more user-friendly interface.

As in newly added doc, you can use read_value! as following.

```rust
let mut sum = 0;
for _ in 0..read_value!(usize) {
    sum += read_value!(u32);
}
assert_eq!(sum, 7);
```

Close #27 