### PR TITLE
Run read_value in cargo test too

### DIFF
--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -19,6 +19,11 @@ path = "tests/stdin.rs"
 harness = false
 
 [[test]]
+name = "read_value"
+path = "tests/read_value.rs"
+harness = false
+
+[[test]]
 name = "interactive"
 path = "tests/interactive.rs"
 harness = false

--- a/proconio/tests/read_value.rs
+++ b/proconio/tests/read_value.rs
@@ -18,7 +18,6 @@ fn test_stdin() {
 fn test_for(input: &str, expected_stdout: &str) {
     use assert_cli::Assert;
     use std::env::args;
-    println!("{:?}", args().next().unwrap());
     Assert::command(&[&*args().next().unwrap(), "foo"])
         .stdin(input)
         .stdout()


### PR DESCRIPTION
We need to add test entry to Cargo.toml. I've completely forgotten how to add an integration test...

Close #52.