### PR TITLE
Bundle ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
           # Replace __cargo_equip → proconio_bundled
           sed "s/__cargo_equip/proconio_bundled/g" build/equip.raw.rs > build/equip.replaced.rs
 
-          # Replace proconio_bundled_macro_def_* -> *
-          sed -i "s/proconio_bundled_macro_def_//g" build/equip.replaced.rs
+          # Replace proconio_bundled_macro_def_proconio_* -> *
+          sed -i "s/proconio_bundled_macro_def_proconio_//g" build/equip.replaced.rs
 
           # Keep from first #[allow(unused)] to the end
           sed -n '/#\[allow(unused)\]/,$p' build/equip.replaced.rs > build/proconio_bundled.rs


### PR DESCRIPTION
Hi, statiolake!

I'm astonished with your work on this repo, but it is not officially included in many online judges. Therefore, I wanted to contribute the small changes for the usability!

This PR creates a CI that bundles all the source codes into a single file, so it is copy-paste ready for competitive programmers. Details are as follows:

1. It checks the tag patterns `v*.*.*` or `*-v*.*.*`. If it matches, the CI will run.
2. It uses the [cargo equip library](https://github.com/qryxip/cargo-equip) to bundle the source file. More specifically, it runs the command `cargo equip --remove docs --remove comments --minify all`.
3. Output source file has some inconvenient naming convensions and redundant documentations, so I added some `sed` commands to make it user-friendly.
4. The bundled source file will be added to your github release page. For example, you will see the release in "Releases" tab in [my forked repository](https://github.com/minux-lee/proconio-rs/tree/bundle-ci).

After the CI completes, you can use the contents in "bundled.rs". You can copy pasted to the source file, and work on the file.