### PR TITLE
Fix read_value_interactive! failing to compile

### DIFF
--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -29,6 +29,11 @@ path = "tests/interactive.rs"
 harness = false
 
 [[test]]
+name = "read_value_interactive"
+path = "tests/read_value_interactive.rs"
+harness = false
+
+[[test]]
 name = "derive"
 path = "tests/derive.rs"
 required-features = ["derive"]

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -711,7 +711,7 @@ macro_rules! input {
 /// This macro is effectively an alias of:
 ///
 /// ```text
-/// let source = procontio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
+/// let source = proconio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
 /// input! {
 ///     from &mut source,
 ///     (mut) variable: type,
@@ -844,7 +844,7 @@ macro_rules! read_value {
 /// This macro is equivalent to do the following:
 ///
 /// ```text
-/// let source = procontio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
+/// let source = proconio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
 /// let variable = read_value!(from &mut source, type);
 /// ```
 ///

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -853,12 +853,12 @@ macro_rules! read_value {
 /// read_value! macro. Read the document of [read_value!](read_value) for further information.
 #[macro_export]
 macro_rules! read_value_interactive {
-    ($($rest:tt)*) => {
-        let mut locked_stdin = $crate::acquire_global_stdin_lock();
+    ($($rest:tt)*) => {{
+        let mut locked_stdin = $crate::__acquire_global_stdin_lock();
         let __res = $crate::read_value!(from &mut *locked_stdin, $($rest)*);
         drop(locked_stdin); // release the lock
         __res
-    };
+    }};
 }
 
 // Acquires the global stdin lock. This must be public because it appears in macro-expanded code,

--- a/proconio/tests/read_value_interactive.rs
+++ b/proconio/tests/read_value_interactive.rs
@@ -1,0 +1,43 @@
+// Copyright 2019 statiolake <statiolake@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
+// distributed except according to those terms.
+
+use proconio::read_value_interactive;
+
+fn test_stdin() {
+    // read_value_interactive! must be usable in expression position
+    let n = read_value_interactive!(usize);
+    println!("{n}");
+
+    let mut sum = 0;
+    for _ in 0..n {
+        sum += read_value_interactive!(u32);
+    }
+    println!("{sum}");
+}
+
+fn test_for(input: &str, expected_stdout: &str) {
+    use assert_cli::Assert;
+    use std::env::args;
+    Assert::command(&[&*args().next().unwrap(), "foo"])
+        .stdin(input)
+        .stdout()
+        .is(expected_stdout)
+        .and()
+        .stderr()
+        .is("")
+        .unwrap();
+}
+
+fn main() {
+    use std::env::args;
+    if args().len() == 1 {
+        test_for("3\n2 3 7\n", "3\n12\n");
+        return;
+    }
+
+    test_stdin();
+}


### PR DESCRIPTION
## Summary

`read_value_interactive!` currently fails to compile whenever it is used, for two independent reasons:

1. **E0425**: commit b996460 renamed the stdin lock helper to `__acquire_global_stdin_lock`, but this macro kept calling `acquire_global_stdin_lock` (without the leading underscores).
2. **Invalid in expression position**: the macro body has been a bare statement sequence (`let ...; ...; __res`) since its introduction, so `let x = read_value_interactive!(usize);` — the documented usage style of `read_value!` — never parsed. Wrapping the body in a block (`{{ ... }}`) fixes it, matching the interface arms of `read_value!`.

Reproduction of both errors on current master:

```text
error: expected expression, found `let` statement
  = note: the usage of `read_value_interactive!` is likely invalid in expression context

error[E0425]: cannot find function `acquire_global_stdin_lock` in crate `$crate`
  help: a function with a similar name exists: `__acquire_global_stdin_lock`
```

## Changes

- Fix the function name and wrap the macro body in a block so it works in expression position.
- Add a test for `read_value_interactive!` (it previously had no coverage at all, which is how this slipped through).
- Fix two "procontio" typos in doc comments.

## Notes

This shares a root cause (b996460) with #60 but is independent of the design decision discussed there — it only makes the macro compile again, without changing which source any macro uses. A follow-up PR implementing the `input_once!` idea from #60 is stacked on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
