### PR TITLE
Add input_once! / read_value_once! and make line-by-line the default (fixes #60)

### DIFF
--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -34,6 +34,16 @@ path = "tests/read_value_interactive.rs"
 harness = false
 
 [[test]]
+name = "input_once"
+path = "tests/input_once.rs"
+harness = false
+
+[[test]]
+name = "mixed_source"
+path = "tests/mixed_source.rs"
+harness = false
+
+[[test]]
 name = "derive"
 path = "tests/derive.rs"
 required-features = ["derive"]

--- a/proconio/Cargo.toml
+++ b/proconio/Cargo.toml
@@ -29,6 +29,11 @@ path = "tests/interactive.rs"
 harness = false
 
 [[test]]
+name = "read_value_interactive"
+path = "tests/read_value_interactive.rs"
+harness = false
+
+[[test]]
 name = "derive"
 path = "tests/derive.rs"
 required-features = ["derive"]

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -711,7 +711,7 @@ macro_rules! input {
 /// This macro is effectively an alias of:
 ///
 /// ```text
-/// let source = procontio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
+/// let source = proconio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
 /// input! {
 ///     from &mut source,
 ///     (mut) variable: type,
@@ -844,7 +844,7 @@ macro_rules! read_value {
 /// This macro is equivalent to do the following:
 ///
 /// ```text
-/// let source = procontio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
+/// let source = proconio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
 /// let variable = read_value!(from &mut source, type);
 /// ```
 ///

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -853,12 +853,12 @@ macro_rules! read_value {
 /// read_value! macro. Read the document of [read_value!](read_value) for further information.
 #[macro_export]
 macro_rules! read_value_interactive {
-    ($($rest:tt)*) => {
-        let mut locked_stdin = $crate::acquire_global_stdin_lock();
+    ($($rest:tt)*) => {{
+        let mut locked_stdin = $crate::__acquire_global_stdin_lock();
         let __res = $crate::read_value!(from &mut *locked_stdin, $($rest)*);
         drop(locked_stdin); // release the lock
         __res
-    };
+    }};
 }
 
 // Acquires the global stdin lock. This must be public because it appears in macro-expanded code,

--- a/proconio/src/lib.rs
+++ b/proconio/src/lib.rs
@@ -313,14 +313,18 @@
 //! assert_eq!(sum, 7);
 //! ```
 //!
-//! # Interactive version
+//! # Interactive problems and `input_once!`
 //!
-//! The normal `input!` and `read_value!` macro reads the entire input at once in judge environment
-//! to optimize I/O performance. However this does not work well with interactive problems, since
-//! in those problems you need to communicate with the judge by writing and reading alternately.
+//! The normal `input!` and `read_value!` macros read the input from stdin line by line.  This
+//! works for interactive problems out of the box, since you can communicate with the judge by
+//! writing and reading alternately.  The deprecated `input_interactive!` and
+//! `read_value_interactive!` macros are kept as aliases of `input!` and `read_value!` for
+//! backward compatibility.
 //!
-//! In this case, you can manually create LineSource for stdin. There's handy interactive version of
-//! the macros doing exactly that. They are `input_interactive!` and `read_value_interactive!`.
+//! If you want to optimize I/O performance for non-interactive problems, you can use
+//! `input_once!` and `read_value_once!` instead.  They read the entire input at once, which is
+//! slightly faster than reading line by line.  Note that they of course don't work with
+//! interactive problems, and cannot be mixed with the line-by-line macros in one program.
 //!
 //! The usage of those macros are exactly the same with the normal ones. Refer to the document of
 //! [input!](input) and [read_value!](read_value) for further information.
@@ -542,7 +546,7 @@ pub use proconio_derive::*;
 pub mod marker;
 pub mod source;
 
-use crate::source::{auto::AutoSource, line::LineSource};
+use crate::source::{line::LineSource, once::OnceSource};
 use std::sync::OnceLock;
 use std::{
     io::{self, BufRead},
@@ -558,25 +562,22 @@ use std::{
 pub use crate::source::Readable as __Readable;
 
 pub enum StdinSource<R: BufRead> {
-    Normal(AutoSource<R>),      // for input!
-    Interactive(LineSource<R>), // for for input_interactive!
-    Unknown(LineSource<R>),     // for is_stdin_empty() without input! or input_interactive!
+    Line(LineSource<R>), // for input!, read_value! and is_stdin_empty()
+    Once(OnceSource<R>), // for input_once! and read_value_once!
 }
 
 impl<R: BufRead> source::Source<R> for StdinSource<R> {
     fn next_token(&mut self) -> Option<&str> {
         match self {
-            StdinSource::Normal(source) => source.next_token(),
-            StdinSource::Interactive(source) => source.next_token(),
-            StdinSource::Unknown(source) => source.next_token(),
+            StdinSource::Line(source) => source.next_token(),
+            StdinSource::Once(source) => source.next_token(),
         }
     }
 
     fn is_empty(&mut self) -> bool {
         match self {
-            StdinSource::Normal(source) => source.is_empty(),
-            StdinSource::Interactive(source) => source.is_empty(),
-            StdinSource::Unknown(source) => source.is_empty(),
+            StdinSource::Line(source) => source.is_empty(),
+            StdinSource::Once(source) => source.is_empty(),
         }
     }
 }
@@ -697,7 +698,7 @@ macro_rules! input {
         }
     };
     ($($rest:tt)*) => {
-        let mut locked_stdin = $crate::__acquire_global_stdin_lock();
+        let mut locked_stdin = $crate::__acquire_global_stdin_lock_line();
         $crate::input! {
             @from [&mut *locked_stdin]
             @rest $($rest)*
@@ -706,29 +707,53 @@ macro_rules! input {
     };
 }
 
-/// Interactive version of input! macro.
+/// Deprecated alias of input! macro.
 ///
-/// This macro is effectively an alias of:
-///
-/// ```text
-/// let source = proconio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
-/// input! {
-///     from &mut source,
-///     (mut) variable: type,
-///     ...
-/// }
-/// ```
-///
-/// With this macro, you always read inputs line-by-line. You can use this as a drop-in replacement
-/// for input! macro in interactive problems. Other than that, usage are the same with input! macro.
-/// Read the document of [input!](input) for further information.
+/// The input! macro now always reads the input line by line and works for interactive problems
+/// out of the box, so this macro is no longer needed. It is kept as an alias of input! for
+/// backward compatibility. Read the document of [input!](input) for further information.
+#[deprecated(
+    since = "0.6.0",
+    note = "`input!` now always reads the input line by line and works for interactive problems; use `input!` instead"
+)]
 #[macro_export]
 macro_rules! input_interactive {
     ($($rest:tt)*) => {
-        let mut locked_stdin = $crate::__acquire_global_stdin_lock();
         $crate::input! {
-            from &mut *locked_stdin,
             $($rest)*
+        }
+    };
+}
+
+/// Faster version of input! macro, reading the entire input at once.
+///
+/// This macro reads the entire input at the first invocation and gives out tokens from the
+/// buffered input afterwards, which is slightly faster than the line-by-line reading of input!
+/// macro. Note the following restrictions:
+///
+/// - It does not work with interactive problems: the first invocation blocks until the input
+///   reaches EOF. For the same reason, when you feed the input by hand in a terminal, you need to
+///   terminate the input by EOF (Ctrl-D on Unix or Ctrl-Z on Windows).
+/// - It cannot be mixed with the line-by-line macros (input!, read_value! or is_stdin_empty())
+///   in one program. Such a mixed use causes a panic at run time.
+/// - It does not support the `from source` syntax. Use input! if you want to read from your own
+///   source.
+///
+/// Other than that, usage are the same with input! macro. Read the document of [input!](input)
+/// for further information.
+#[macro_export]
+macro_rules! input_once {
+    (from $($rest:tt)*) => {
+        compile_error!(concat!(
+            "`input_once!` does not support the `from source` syntax.  ",
+            "Use `input!` with your own source instead."
+        ));
+    };
+    ($($rest:tt)*) => {
+        let mut locked_stdin = $crate::__acquire_global_stdin_lock_once();
+        $crate::input! {
+            @from [&mut *locked_stdin]
+            @rest $($rest)*
         }
         drop(locked_stdin); // release the lock
     };
@@ -820,57 +845,95 @@ macro_rules! read_value {
         $crate::read_value!(@source [&mut s] @kind [$($rest)*])
     }};
     ($($rest:tt)*) => {{
-        let mut locked_stdin = $crate::STDIN_SOURCE
-            .get_or_init(|| {
-                std::sync::Mutex::new($crate::StdinSource::Normal(
-                    $crate::source::auto::AutoSource::new(std::io::BufReader::new(std::io::stdin())),
-                ))
-            })
-            .lock()
-            .expect(concat!(
-                "failed to lock the stdin; please re-run this program.  ",
-                "If this issue repeatedly occur, this is a bug in `proconio`.  ",
-                "Please report this issue from ",
-                "<https://github.com/statiolake/proconio-rs/issues>."
-            ));
+        let mut locked_stdin = $crate::__acquire_global_stdin_lock_line();
         let __res = $crate::read_value!(from &mut *locked_stdin, $($rest)*);
         drop(locked_stdin); // release the lock
         __res
     }};
 }
 
-/// Interactive version of `read_value!` macro.
+/// Deprecated alias of `read_value!` macro.
 ///
-/// This macro is equivalent to do the following:
-///
-/// ```text
-/// let source = proconio::source::line::LineSource::new(BufReader::new(std::io::stdin()));
-/// let variable = read_value!(from &mut source, type);
-/// ```
-///
-/// With this macro, you always read inputs line-by-line. You can use this as a drop-in replacement
-/// for read_value! macro in interactive problems. Other than that, usage are the same with
-/// read_value! macro. Read the document of [read_value!](read_value) for further information.
+/// The read_value! macro now always reads the input line by line and works for interactive
+/// problems out of the box, so this macro is no longer needed. It is kept as an alias of
+/// read_value! for backward compatibility. Read the document of [read_value!](read_value) for
+/// further information.
+#[deprecated(
+    since = "0.6.0",
+    note = "`read_value!` now always reads the input line by line and works for interactive problems; use `read_value!` instead"
+)]
 #[macro_export]
 macro_rules! read_value_interactive {
+    ($($rest:tt)*) => {
+        $crate::read_value!($($rest)*)
+    };
+}
+
+/// Faster version of `read_value!` macro, reading the entire input at once.
+///
+/// The restrictions of [input_once!](input_once) apply to this macro as well: it does not work
+/// with interactive problems, cannot be mixed with the line-by-line macros in one program, and
+/// does not support the `from source` syntax. Other than that, usage are the same with
+/// read_value! macro. Read the document of [read_value!](read_value) for further information.
+#[macro_export]
+macro_rules! read_value_once {
+    (from $($rest:tt)*) => {
+        compile_error!(concat!(
+            "`read_value_once!` does not support the `from source` syntax.  ",
+            "Use `read_value!` with your own source instead."
+        ));
+    };
     ($($rest:tt)*) => {{
-        let mut locked_stdin = $crate::__acquire_global_stdin_lock();
+        let mut locked_stdin = $crate::__acquire_global_stdin_lock_once();
         let __res = $crate::read_value!(from &mut *locked_stdin, $($rest)*);
         drop(locked_stdin); // release the lock
         __res
     }};
 }
 
-// Acquires the global stdin lock. This must be public because it appears in macro-expanded code,
-// but hidden in doc because this implementation detail should be considered as private.
+// Acquires the global stdin lock, initializing the source as the line-by-line reader if it is not
+// initialized yet. This must be public because it appears in macro-expanded code, but hidden in
+// doc because this implementation detail should be considered as private.
 #[doc(hidden)]
-pub fn __acquire_global_stdin_lock() -> MutexGuard<'static, StdinSource<BufReader<Stdin>>> {
+pub fn __acquire_global_stdin_lock_line() -> MutexGuard<'static, StdinSource<BufReader<Stdin>>> {
+    let locked_stdin = lock_global_stdin_source(|| {
+        StdinSource::Line(LineSource::new(BufReader::new(io::stdin())))
+    });
+    if let StdinSource::Once(_) = &*locked_stdin {
+        panic!(concat!(
+            "cannot use `input!` / `read_value!` (or their deprecated `_interactive` aliases) ",
+            "or `is_stdin_empty()` after `input_once!` / `read_value_once!`: the stdin source ",
+            "is already initialized to read the entire input at once.  ",
+            "Please use only one family of the macros in a program."
+        ));
+    }
+    locked_stdin
+}
+
+// Acquires the global stdin lock, initializing the source as the read-at-once reader if it is not
+// initialized yet. This must be public because it appears in macro-expanded code, but hidden in
+// doc because this implementation detail should be considered as private.
+#[doc(hidden)]
+pub fn __acquire_global_stdin_lock_once() -> MutexGuard<'static, StdinSource<BufReader<Stdin>>> {
+    let locked_stdin = lock_global_stdin_source(|| {
+        StdinSource::Once(OnceSource::new(BufReader::new(io::stdin())))
+    });
+    if let StdinSource::Line(_) = &*locked_stdin {
+        panic!(concat!(
+            "cannot use `input_once!` / `read_value_once!` after `input!` / `read_value!` ",
+            "(or their deprecated `_interactive` aliases) or `is_stdin_empty()`: the stdin ",
+            "source is already initialized to read the input line by line.  ",
+            "Please use only one family of the macros in a program."
+        ));
+    }
+    locked_stdin
+}
+
+fn lock_global_stdin_source(
+    init: impl FnOnce() -> StdinSource<BufReader<Stdin>>,
+) -> MutexGuard<'static, StdinSource<BufReader<Stdin>>> {
     STDIN_SOURCE
-        .get_or_init(|| {
-            Mutex::new(StdinSource::Unknown(LineSource::new(BufReader::new(
-                io::stdin(),
-            ))))
-        })
+        .get_or_init(|| Mutex::new(init()))
         .lock()
         .expect(concat!(
             "failed to lock the stdin; please re-run this program.  ",
@@ -896,7 +959,12 @@ pub fn __acquire_global_stdin_lock() -> MutexGuard<'static, StdinSource<BufReade
 /// ```
 pub fn is_stdin_empty() -> bool {
     use source::Source;
-    let mut lock = __acquire_global_stdin_lock();
+    // Note: this works with whichever source is in use, but if this is the first access to
+    // stdin, it initializes the source as the line-by-line reader. In other words, calling this
+    // function first and then using `input_once!` / `read_value_once!` is not allowed.
+    let mut lock = lock_global_stdin_source(|| {
+        StdinSource::Line(LineSource::new(BufReader::new(io::stdin())))
+    });
     lock.is_empty()
 }
 

--- a/proconio/src/source/mod.rs
+++ b/proconio/src/source/mod.rs
@@ -12,14 +12,16 @@
 //! 1. Read entire source at once.  (`once::OnceSource`)
 //! 1. Read source line by line.  (`line::LineSource`)
 //!
-//! `OnceSource` is very fast, while `LineSource` is handy for local debugging. `OnceSource` must
-//! read entire input before any other work and you must put EOF (Ctrl-D on Unix or Ctrl-Z on
-//! Windows) after input.  LineSource reads source one by one.  Simply press enter to input.
+//! `OnceSource` is very fast, while `LineSource` is handy for local debugging and interactive
+//! problems. `OnceSource` must read entire input before any other work and you must put EOF
+//! (Ctrl-D on Unix or Ctrl-Z on Windows) after input.  LineSource reads source one by one.
+//! Simply press enter to input.
 //!
 //! There is another source named `auto::AutoSource`.  `AutoSource` is `OnceSource` in release
-//! build, is `LineSource` in debug build.  If you use debug build in local testing, `LineSource`,
-//! convenience version is used.  In judge server it is compiled in release mode, so `OnceSource`,
-//! faster version is used.  This is usually no problem in judging (except interactive problem?).
+//! build, is `LineSource` in debug build.  This source is kept for backward compatibility, but
+//! it is no longer used by the macros: `input!` always uses `LineSource` and `input_once!`
+//! always uses `OnceSource`, regardless of the build profile, so that the behavior does not
+//! differ between local testing and the judge server.
 //!
 //! You can specify the source to be used in `input!` as follows:
 //!
@@ -47,11 +49,10 @@
 //! directly from the value of type implementing `BufRead` by using `OnceSource::new()` and
 //! `LineSource::new()`.
 //!
-//! If you use `input!` macro with no source specified then it uses `AutoSource` with stdin.  So,
-//! locally `LineSource` are used, in the server `OnceSource` are used.  `OnceSource` and
-//! `LineSource` behaves samely in point of the read result, but, unintentionally, it may differ in
-//! a bare possibility. If it should differ, you can manually specify `LineSource` as `source` of
-//! `input!`.
+//! If you use `input!` macro with no source specified then it uses `LineSource` with stdin, and
+//! `input_once!` uses `OnceSource` with stdin.  `OnceSource` and `LineSource` behaves samely in
+//! point of the read result, but, unintentionally, it may differ in a bare possibility. If it
+//! should differ, you can manually specify the source of `input!`.
 use std::any::type_name;
 use std::fmt::Debug;
 use std::io::BufRead;

--- a/proconio/tests/input_once.rs
+++ b/proconio/tests/input_once.rs
@@ -1,0 +1,44 @@
+// Copyright 2019 statiolake <statiolake@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
+// distributed except according to those terms.
+
+use proconio::{input_once, read_value_once};
+
+fn test_stdin() {
+    input_once! {
+        n: usize,
+    }
+    println!("{n}");
+
+    let mut sum = 0;
+    for _ in 0..n {
+        sum += read_value_once!(u32);
+    }
+    println!("{sum}");
+}
+
+fn test_for(input: &str, expected_stdout: &str) {
+    use assert_cli::Assert;
+    use std::env::args;
+    Assert::command(&[&*args().next().unwrap(), "foo"])
+        .stdin(input)
+        .stdout()
+        .is(expected_stdout)
+        .and()
+        .stderr()
+        .is("")
+        .unwrap();
+}
+
+fn main() {
+    use std::env::args;
+    if args().len() == 1 {
+        test_for("3\n2 3 7\n", "3\n12\n");
+        return;
+    }
+
+    test_stdin();
+}

--- a/proconio/tests/interactive.rs
+++ b/proconio/tests/interactive.rs
@@ -5,6 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
 // distributed except according to those terms.
 
+// input_interactive! is deprecated but must keep working as an alias of input!
+#![allow(deprecated)]
+
 use proconio::{input_interactive, is_stdin_empty};
 
 fn test_stdin() {

--- a/proconio/tests/mixed_source.rs
+++ b/proconio/tests/mixed_source.rs
@@ -1,0 +1,43 @@
+// Copyright 2019 statiolake <statiolake@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
+// distributed except according to those terms.
+
+use proconio::{input, input_once};
+
+fn test_stdin() {
+    input! {
+        n: usize,
+    }
+    println!("{n}");
+
+    // mixing the line-by-line macros and the read-at-once macros must panic
+    input_once! {
+        m: usize,
+    }
+    println!("{m}");
+}
+
+fn test_panics(input: &str) {
+    use assert_cli::Assert;
+    use std::env::args;
+    Assert::command(&[&*args().next().unwrap(), "foo"])
+        .stdin(input)
+        .fails()
+        .and()
+        .stderr()
+        .contains("cannot use `input_once!` / `read_value_once!` after")
+        .unwrap();
+}
+
+fn main() {
+    use std::env::args;
+    if args().len() == 1 {
+        test_panics("1 2\n");
+        return;
+    }
+
+    test_stdin();
+}

--- a/proconio/tests/read_value_interactive.rs
+++ b/proconio/tests/read_value_interactive.rs
@@ -5,6 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
 // distributed except according to those terms.
 
+// read_value_interactive! is deprecated but must keep working as an alias of read_value!
+#![allow(deprecated)]
+
 use proconio::read_value_interactive;
 
 fn test_stdin() {

--- a/proconio/tests/read_value_interactive.rs
+++ b/proconio/tests/read_value_interactive.rs
@@ -1,0 +1,43 @@
+// Copyright 2019 statiolake <statiolake@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
+// distributed except according to those terms.
+
+use proconio::read_value_interactive;
+
+fn test_stdin() {
+    // read_value_interactive! must be usable in expression position
+    let n = read_value_interactive!(usize);
+    println!("{n}");
+
+    let mut sum = 0;
+    for _ in 0..n {
+        sum += read_value_interactive!(u32);
+    }
+    println!("{sum}");
+}
+
+fn test_for(input: &str, expected_stdout: &str) {
+    use assert_cli::Assert;
+    use std::env::args;
+    Assert::command(&[&*args().next().unwrap(), "foo"])
+        .stdin(input)
+        .stdout()
+        .is(expected_stdout)
+        .and()
+        .stderr()
+        .is("")
+        .unwrap();
+}
+
+fn main() {
+    use std::env::args;
+    if args().len() == 1 {
+        test_for("3\n2 3 7\n", "3\n12\n");
+        return;
+    }
+
+    test_stdin();
+}


### PR DESCRIPTION
## Summary

Fixes #60 by implementing the `input_once!` direction you suggested there, rather than reverting to the 0.4.5 behavior:

> I think it might be better to keep `input!` as-is and create a separate macro like `input_once!` for faster input instead. [...] we're seeing more and more interactive problems, especially in AHC. So maybe we should focus on interactive problems first?

If you prefer the revert direction instead, feel free to close this PR — the changes are intentionally kept small so that either decision is cheap.

**Stacked on #63** — the first 3 commits belong to that PR; please review only the last 2 commits here.

## Changes

- `input!` / `read_value!` now always read stdin line by line, in every build profile, and therefore work for interactive problems out of the box. This formalizes what 0.5.0 already (accidentally) does, so there is no behavior change relative to the released 0.5.0 — except for source-less `read_value!`, which had been left on `AutoSource` by the b996460 refactoring and was inconsistent with `input!`.
- New `input_once!` / `read_value_once!` read the entire input at once, restoring the 0.4.5 release-build performance as an explicit opt-in.
- `input_interactive!` / `read_value_interactive!` are deprecated and kept as thin aliases of `input!` / `read_value!`, so existing code keeps compiling (with a deprecation note pointing to the replacement).
- `StdinSource` variants are reworked to `Line` / `Once`; the previous `Normal` / `Interactive` / `Unknown` split no longer matched how sources were actually constructed (`Interactive` had become impossible to construct).
- `source::auto::AutoSource` is kept for backward compatibility but is no longer used by any macro.

## Design decisions (please push back on any of these)

1. **`input_once!` uses `OnceSource` in debug builds too**, unlike the old `AutoSource` (debug = `LineSource`). Rationale: the debug/release split has confused users before (#17), and the friendly line-by-line behavior for manual terminal input is now what plain `input!` provides. With the split, an interactive problem accidentally using `input_once!` would pass local debug testing and then deadlock on the judge; with unconditional `OnceSource`, the mistake reproduces locally.
2. **Mixing the line-by-line macros with the read-at-once macros in one program panics** with an explanatory message, instead of silently reusing whichever source was initialized first. This implements what you proposed in the review discussion of #34 ("it's also possible to detect mixed use [...] at run-time and we can panic! to warn user about it"). `is_stdin_empty()` works with either family, but counts as line-by-line if it is the first stdin access.
3. `input_once!` / `read_value_once!` reject the `from source` syntax with a `compile_error!` pointing to `input!` / `read_value!`, since an explicit source makes the global-source choice meaningless.

Since the `StdinSource` variants are public (though effectively internal), this is technically a breaking change — probably worth releasing as 0.6.0.

## Testing

- New tests: `input_once` (both new macros end to end) and `mixed_source` (mixed use panics).
- Existing `interactive` / `read_value_interactive` tests now exercise the deprecated aliases, verifying they still work.
- Verified by hand that `input!` responds line by line before EOF in release builds, and that `input_once!` blocks until EOF in both profiles.
- `cargo test --workspace --all-features`, `cargo test --release`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
